### PR TITLE
Win64 crash in asm.js

### DIFF
--- a/js/src/jit/x64/Assembler-x64.cpp
+++ b/js/src/jit/x64/Assembler-x64.cpp
@@ -38,8 +38,8 @@ ABIArgGenerator::next(MIRType type)
             current_ = ABIArg(stackOffset_);
             stackOffset_ += Simd128DataSize;
         } else {
-            stackOffset_ += sizeof(uint64_t);
             current_ = ABIArg(stackOffset_);
+            stackOffset_ += sizeof(uint64_t);            
         }
         return current_;
     }


### PR DESCRIPTION
Return stack offset before incrementing it for win64 Bug #1071444
P.s Merry Christmas
