### PR TITLE
User controlled duplicate tab menu item.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -446,6 +446,7 @@ pref("browser.tabs.loadDivertedInBackground", false);
 pref("browser.tabs.loadBookmarksInBackground", false);
 pref("browser.tabs.tabClipWidth", 140);
 pref("browser.tabs.animate", true);
+pref("browser.tabs.duplicateTab", true);
 #ifdef UNIX_BUT_NOT_MAC
 pref("browser.tabs.drawInTitlebar", false);
 #else

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -7749,6 +7749,14 @@ var TabContextMenu = {
       toggleMute.accessKey = gNavigatorBundle.getString("muteTab.accesskey");
     }
 
+    // Adjust the state of duplicate Tab menu item.
+    let toggleDuplicateTab = document.getElementById("context_duplicateTab");
+    if (Services.prefs.getBoolPref("browser.tabs.duplicateTab")){
+      toggleDuplicateTab.hidden = false;
+    } else {
+      toggleDuplicateTab.hidden = true;
+    }
+    
     this.contextTab.toggleMuteMenuItem = toggleMute;
     this._updateToggleMuteMenuItem(this.contextTab);
 


### PR DESCRIPTION
This change allows users to toggle `"browser.tabs.duplicateTab"` preference. When toggled the `Duplicate Tab` menu item toggles.

Many extensions like tab mix plus add these entries with users ending up with multiple entries for the same function. This allows **users choice** in customization of there browser installation.

Linking to current tracked issue https://github.com/MrAlex94/Waterfox/issues/95