### PR TITLE
Fix crash and dos with language selection

### DIFF
--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -87,7 +87,10 @@ var gMainPane = {
     setEventListener("localeSelect", "popuphiding", function () {
       gMainPane.updateLocale();
     });
-
+    setEventListener("localeSelect", "keypress", function (e) {
+      gMainPane._updateLocale(e);
+    });
+	
     if (AppConstants.E10S_TESTING_ONLY) {
       setEventListener("e10sAutoStart", "command",
                        gMainPane.enableE10SChange);
@@ -143,7 +146,13 @@ var gMainPane = {
       alertsService.showAlertNotification("",  "Restart Waterfox", "You'll need to restart Waterfox to see your selected locale.");
     }
   },
-
+  _updateLocale: function (e)
+  {
+    if (e.which == 13 || e.keyCode == 13){
+		  this.updateLocale();
+    }
+  },
+    
   enableE10SChange: function ()
   {
     if (AppConstants.E10S_TESTING_ONLY) {

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -129,7 +129,9 @@ var gMainPane = {
   // Sets language selector to current locale value
   getDefaultLocal: function(){
 	  let selectedLocale = document.getElementById("localeSelect");
-	  document.getElementById("localeSelect").value = Services.prefs.getCharPref('general.useragent.locale');
+	  if (selectedLocale){
+	  	selectedLocale.value = Services.prefs.getCharPref('general.useragent.locale');
+	  }
   },
   
   updateLocale: function ()

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -28,7 +28,7 @@ var gMainPane = {
       document.getElementById(aId)
               .addEventListener(aEventType, aCallback.bind(gMainPane));
     }
-    this.updateLocale();
+    this.getDefaultLocal();
     if (AppConstants.HAVE_SHELL_SERVICE) {
       this.updateSetDefaultBrowser();
       if (AppConstants.platform == "win") {
@@ -125,7 +125,13 @@ var gMainPane = {
               .getService(Components.interfaces.nsIObserverService)
               .notifyObservers(window, "main-pane-loaded", null);
   },
-
+  
+  // Sets language selector to current locale value
+  getDefaultLocal: function(){
+	  let selectedLocale = document.getElementById("localeSelect");
+	  document.getElementById("localeSelect").value = Services.prefs.getCharPref('general.useragent.locale');
+  },
+  
   updateLocale: function ()
   {
     let alertsService = Cc["@mozilla.org/alerts-service;1"].getService(Ci.nsIAlertsService);

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -84,7 +84,7 @@ var gMainPane = {
     setEventListener("chooseFolder", "command",
                      gMainPane.chooseFolder);
 
-    setEventListener("localeSelect", "command", function () {
+    setEventListener("localeSelect", "popuphiding", function () {
       gMainPane.updateLocale();
     });
 


### PR DESCRIPTION
This is to address patch efa1f09 brought with it a series of issues and reported issue #99.

-  ~~Using arrow keys for selection causes large CPU spiking~~
-  ~~Using arrow keys causes memory leak from notification spam~~
-  ~~Using arrow keys can crash waterfox~~
-  ~~Using arrow keys creates browser lag creating a denial of service for few seconds to few minutes~~

This proposed change only fires an event when the language selection popup closes, ~~this however does introduce another limitation. When using tab to select control element then when selecting with arrow keys no longer selects the items but on `onkeypress` event with function preventing default and binding to the enter (return key) once selection with arrow keys are made when using tab index to select GUI elements.~~

This change also sets the current default language without triggering `updateLocale` event.




