### PR TITLE
Minor adjustments to language selection

### DIFF
--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -141,6 +141,9 @@ var gMainPane = {
   {
     let alertsService = Cc["@mozilla.org/alerts-service;1"].getService(Ci.nsIAlertsService);
     let selectedLocale = document.getElementById("localeSelect").value;
+	  
+    if (selectedLocale === Services.prefs.getCharPref('general.useragent.locale')) return;
+	
     if (selectedLocale != "") {
       Services.prefs.setCharPref('general.useragent.locale', selectedLocale);
       alertsService.showAlertNotification("",  "Restart Waterfox", "You'll need to restart Waterfox to see your selected locale.");

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -84,7 +84,7 @@ var gMainPane = {
     setEventListener("chooseFolder", "command",
                      gMainPane.chooseFolder);
 
-    setEventListener("localeSelect", "popuphiding", function () {
+    setEventListener("localeSelect", "popuphidden", function () {
       gMainPane.updateLocale();
     });
     setEventListener("localeSelect", "keypress", function (e) {


### PR DESCRIPTION
This change addresses a minor issue with current `popuphiding` event listener, if focus was taken from the drop down menu the `updateLocale()` would trigger regardless of user selection. The current change resolves this.

The next change address a minor issue where when selecting the current locale `updateLocale()` would trigger.