### PR TITLE
Update aboutHome.css

### DIFF
--- a/browser/base/content/abouthome/aboutHome.css
+++ b/browser/base/content/abouthome/aboutHome.css
@@ -328,7 +328,7 @@ body[narrow] #restorePreviousSession::before {
   display: block;
   position: absolute;
   top: 12px;
-  right: 12px;
+  right: 69px;
   width: 69px;
   height: 19px;
 }


### PR DESCRIPTION
Fix Waterfox link's wrong position. The right value in abouthome.css for Waterfox link should be as same as width value.