### PR TITLE
Small fix for dont-override-general-useragent-locale.patch

### DIFF
--- a/browser/locales/en-US/firefox-l10n.js
+++ b/browser/locales/en-US/firefox-l10n.js
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#ifdef XP_WIN || XP_MACOSX
+
 #filter substitution
-#endif
+
 
 # LOCALIZATION NOTE: this preference is set to true for en-US specifically,
 # locales without this line have the setting set to false by default.


### PR DESCRIPTION
I removed two lines, because these lines are just not needed.