### PR TITLE
Remove addon information from addon discovery url

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.js
+++ b/toolkit/mozapps/extensions/content/extensions.js
@@ -2339,7 +2339,7 @@ var gDiscoverView = {
         }
       }
 
-      setURL(url + "#" + JSON.stringify(list));
+      setURL(url);
     });
   },
 


### PR DESCRIPTION
Fixes crash in https://github.com/MrAlex94/Waterfox/issues/146 with NoScript Security Suite
Stops sending of all installed addons to Mozilla every time you open the "Get Addons Page" better privacy.