### PR TITLE
Fix default browser #2

### DIFF
--- a/browser/installer/windows/nsis/defines.nsi.in
+++ b/browser/installer/windows/nsis/defines.nsi.in
@@ -28,8 +28,8 @@
 
 !define FileMainEXE           "@MOZ_APP_NAME@.exe"
 !define WindowClass           "FirefoxMessageWindow"
-!define DDEApplication        "Firefox"
-!define AppRegName            "Firefox"
+!define DDEApplication        "Waterfox"
+!define AppRegName            "Waterfox"
 
 !ifndef DEV_EDITION
 !define BrandShortName        "@MOZ_APP_DISPLAYNAME@"


### PR DESCRIPTION
This is another pull request to fix #343 via changing the relevant registry keys/values to use Waterfox instead of Firefox.
A few parts of the code for default browser registration code used ${AppRegName} while other parts used a hard code value of Firefox.
I think when I did my first pull request it just didn't occur to me to check what file was setting AppRegName and make sure to update that file too.

I noticed this after installing Waterfox 56.0.2 and seeing that some registry keys were still not changed.
In hindsight, it's an obvious thing that I should have checked but I guess it just didn't occur to me.

While updating defines.nsi.h, I also changed DDEApplication to Waterfox also.
I think this is the name a program would use if it were to use DDE to interact with Waterfox but I'm not sure anything really uses DDE anymore so it may not matter that much.

There is also an AppName value set to Firefox but as it's not related to associations (DDE can be related) from what I can tell, this is not the place to change it.
  