### PR TITLE
Update defines.nsi.in to fix two minor installer issues

### DIFF
--- a/browser/installer/windows/nsis/defines.nsi.in
+++ b/browser/installer/windows/nsis/defines.nsi.in
@@ -21,13 +21,13 @@
 !endif
 
 # These defines should match application.ini settings
-!define AppName               "Firefox"
+!define AppName               "Waterfox"
 !define AppVersion            "@APP_VERSION@"
 !define GREVersion            @MOZILLA_VERSION@
 !define AB_CD                 "@AB_CD@"
 
 !define FileMainEXE           "@MOZ_APP_NAME@.exe"
-!define WindowClass           "FirefoxMessageWindow"
+!define WindowClass           "WaterfoxMessageWindow"
 !define DDEApplication        "Waterfox"
 !define AppRegName            "Waterfox"
 


### PR DESCRIPTION
I looked into the defines.nsi.in file some more after doing my last pull request and found the following:
* AppName is used for the registry key Software\Mozilla\\[AppName]\TaskBarIDs
I'm not quite sure what this key is used for but Pale Moon and Basilisk appear to have updated the AppName value so it should probably be changed for Waterfox too.
* WindowClass is used by the installer when deciding if the program is already running if a user decides to launch the program after install.
According to [Basilisk issue #170](https://github.com/MoonchildProductions/moebius/issues/170) this needs to be set to AppName + "MessageWindow" as that is what the installer will assume to be the case should a user select to run the browser after installation and using the default value of "FirefoxMessageWindow" will cause the installer in that case to assume the browser is already running if Firefox is running and refuse to launch the browser.
Edit: This fixes issue #353.

This pull request fixes those two minor issues.