### PR TITLE
Hacky Installer Change to remove Firefox-$AppUserModelId registry key and value

### DIFF
--- a/browser/installer/windows/nsis/shared.nsh
+++ b/browser/installer/windows/nsis/shared.nsh
@@ -537,6 +537,12 @@
 !macro SetStartMenuInternet RegKey
   ${GetLongPath} "$INSTDIR\${FileMainEXE}" $8
   ${GetLongPath} "$INSTDIR\uninstall\helper.exe" $7
+  
+  ; Handle the Firefox-$AppUserModelID Key and Value that can exist
+  ; from previous Waterfox versions where ${AppRegName} was set to "Firefox".
+  DeleteRegKey ${RegKey} "Software\Clients\StartMenuInternet\Firefox-$AppUserModelID"
+  DeleteRegValue ${RegKey} "Software\RegisteredApplications" "Firefox-$AppUserModelID"
+  ClearErrors
 
   ; If we already have keys at the old FIREFOX.EXE path, then just update those.
   ; We have to be careful to update the existing keys in place so that we don't


### PR DESCRIPTION
Edit: Found better way to patch this issue, will do new pull request soon.

While figuring out how to deal with issue #363, I realized that the change in #362 would end up leaving these things in the registry:
* Key Software\Clients\StartMenuInternet\Firefox-$AppUserModelID
* Value Firefox-$AppUserModelID in key Software\RegisteredApplications

If those are not removed by the installer during an upgrade then there will be two entries for Waterfox in the registry.

This may cause identical Waterfox entries (Due to each key having a Display Name value set to Waterfox) to be displayed in the Set Default Programs Control Panel and possibly other issues.

This commit attempts to solve this problem by just having the installer attempt to delete those from the registry if they exist and then ignore any errors to handle the case where the old registry things are not there to be removed.

This is probably not the best way to solve this thus the "Hacky Installer Change" part of the title.
I'm also not sure if this code will work properly because I just copied some code from the uninstaller, changed it and added ClearErrors to ignore any errors it might produce.

I'm not that familiar with coding in NSIS and I don't have all of various programs needed to compile the Mozilla code base installed and setup to allow me to test if this change will work well or not.

I'm not sure if NSIS has any registry commands for only doing something only if a key exists or for renaming a key but if it does then those commands may work better.

I thought about just not creating this pull request but decided to do so anyway to list what the problem is and one way to deal with it.