### PR TITLE
Update Installer to remove old registry keys/values that use "Firefox"

### DIFF
--- a/browser/installer/windows/nsis/installer.nsi
+++ b/browser/installer/windows/nsis/installer.nsi
@@ -251,6 +251,10 @@ Section "-InstallStartCleanup"
 
   ; setup the application model id registration value
   ${InitHashAppModelId} "$INSTDIR" "Software\Mozilla\${AppName}\TaskBarIDs"
+  
+  ; Remove old application model id stored under the Firefox key
+  DeleteRegValue HKCU "Software\Mozilla\Firefox\TaskBarIDs" "$INSTDIR"
+  DeleteRegValue HKLM "Software\Mozilla\Firefox\TaskBarIDs" "$INSTDIR"
 
   ; Remove the updates directory
   ${CleanUpdateDirectories} "Mozilla\Firefox" "Mozilla\updates"

--- a/browser/installer/windows/nsis/shared.nsh
+++ b/browser/installer/windows/nsis/shared.nsh
@@ -1000,6 +1000,12 @@
   ; Remove protocol handler registry keys added by the MS shim
   DeleteRegKey HKLM "Software\Classes\Waterfox.URL"
   DeleteRegKey HKCU "Software\Classes\Waterfox.URL"
+
+  ; Remove old browser registration with "Firefox" prefix from registry
+  DeleteRegKey HKLM "Software\Clients\StartMenuInternet\Firefox-$AppUserModelID"
+  DeleteRegValue HKLM "Software\RegisteredApplications" "Firefox-$AppUserModelID"
+  DeleteRegKey HKCU "Software\Clients\StartMenuInternet\Firefox-$AppUserModelID"
+  DeleteRegValue HKCU "Software\RegisteredApplications" "Firefox-$AppUserModelID"
 !macroend
 !define RemoveDeprecatedKeys "!insertmacro RemoveDeprecatedKeys"
 


### PR DESCRIPTION
This is a better patch then the one I did in pull request #372 that should solve the problem of duplicate Waterfox entries in Set Default Programs described in #384.

After spending more time looking to the installer code, I found the following:
1. I didn't need to use ClearErrors as if appears that any code that checks for errors already will call that first before an operation that it needs to look at the error results of.
2. The existing installer code already uses DeleteRegKey and DeleteRegKey to handle older keys that may not exist so it is the correct way to deal with this issue.
3. When removing old registry keys, it appears better to just delete them from both the HKLM and HKCU keys as you can't be sure that the root key the install currently uses is the only place they might be.
4. Put the removal of the browser registration keys in the RemoveDeprecatedKeys macro as that marco is already there for the purpose of removing old keys/values that aren't used anymore.
5. Add code to remove the old values added by the install that adds the app model id to the registry.
Functionally, this should make no difference but it's probably best to remove values the installer doesn't use anymore that would only be used by older Waterfox versions.

I'm a lot more confident in this code then the pull request I did before to clean up old browser registration keys.
Hopefully after this patch, there will no longer be any problems when someone wants to set Waterfox as their default browser.