### PR TITLE
Expose media.gmp-manager.updateEnabled in about:config by default

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5572,6 +5572,9 @@ pref("browser.search.official", true);
 
 // GMPInstallManager prefs
 
+// Whether updates are enabled
+pref("media.gmp-manager.updateEnabled", true);
+
 // User-settable override to media.gmp-manager.url for testing purposes.
 //pref("media.gmp-manager.url.override", "");
 


### PR DESCRIPTION
Flipping this pref is required to stop Waterfox from phoning home to Mozilla and Cisco and automatically downloading binaries.  It should be visible in about:config by default.

(To be clear, this patch **does not** change the default value of this pref.)