### PR TITLE
Fix extension compatibility post-Firefox 59 release

### DIFF
--- a/toolkit/modules/addons/WebRequest.jsm
+++ b/toolkit/modules/addons/WebRequest.jsm
@@ -181,23 +181,38 @@ class HeaderChanger {
       }
     }
 
-    // Set new or changed headers.
+    // Set new or changed headers.  If there are multiple headers with the same
+    // name (e.g. Set-Cookie), merge them, instead of having new values
+    // overwrite previous ones.
+    //
+    // When the new value of a header is equal the existing value of the header
+    // (e.g. the initial response set "Set-Cookie: examplename=examplevalue",
+    // and an extension also added the header
+    // "Set-Cookie: examplename=examplevalue") then the header value is not
+    // re-set, but subsequent headers of the same type will be merged in.
+    let headersAlreadySet = new Set();
     for (let {name, value, binaryValue} of headers) {
       if (binaryValue) {
         value = String.fromCharCode(...binaryValue);
       }
-      let original = this.originalHeaders.get(name.toLowerCase());
+
+      let lowerCaseName = name.toLowerCase();
+      let original = this.originalHeaders.get(lowerCaseName);
+
       if (!original || value !== original.value) {
-        this.setHeader(name, value);
+        let shouldMerge = headersAlreadySet.has(lowerCaseName);
+        this.setHeader(name, value, shouldMerge);
       }
+
+      headersAlreadySet.add(lowerCaseName);
     }
   }
 }
 
 class RequestHeaderChanger extends HeaderChanger {
-  setHeader(name, value) {
+  setHeader(name, value, merge) {
     try {
-      this.channel.setRequestHeader(name, value, false);
+      this.channel.setRequestHeader(name, value, merge);
     } catch (e) {
       Cu.reportError(new Error(`Error setting request header ${name}: ${e}`));
     }
@@ -211,7 +226,7 @@ class RequestHeaderChanger extends HeaderChanger {
 }
 
 class ResponseHeaderChanger extends HeaderChanger {
-  setHeader(name, value) {
+  setHeader(name, value, merge) {
     try {
       if (name.toLowerCase() === "content-type" && value) {
         // The Content-Type header value can't be modified, so we
@@ -222,7 +237,7 @@ class ResponseHeaderChanger extends HeaderChanger {
 
         getData(this.channel).contentType = value;
       } else {
-        this.channel.setResponseHeader(name, value, false);
+        this.channel.setResponseHeader(name, value, merge);
       }
     } catch (e) {
       Cu.reportError(new Error(`Error setting response header ${name}: ${e}`));


### PR DESCRIPTION
With the release of Firefox 59, some extensions like uBlock Origin now expect webRequest to merge multiple request/response headers with the same name.  Waterfox currently overwrites instead of merging.  This breaks current versions of uBlock Origin.

See test case: https://github.com/gorhill/uMatrix/issues/967#issuecomment-373002011

This patch fixes it by porting the post-59 behavior to Waterfox.