### PR TITLE
Allow setting UTF-8 as fallback

### DIFF
--- a/dom/encoding/FallbackEncoding.cpp
+++ b/dom/encoding/FallbackEncoding.cpp
@@ -54,8 +54,7 @@ FallbackEncoding::Get()
   // Don't let the user break things by setting the override to unreasonable
   // values via about:config
   auto encoding = Encoding::ForLabel(override);
-  if (!encoding || !encoding->IsAsciiCompatible() ||
-      encoding == UTF_8_ENCODING) {
+  if (!encoding || !encoding->IsAsciiCompatible()) {
     mFallback = nullptr;
   } else {
     mFallback = encoding;


### PR DESCRIPTION
Fixes https://github.com/MrAlex94/Waterfox/issues/450