### PR TITLE
Make source downloads more reproducible

### DIFF
--- a/addon-sdk/source/.gitattributes
+++ b/addon-sdk/source/.gitattributes
@@ -2,4 +2,3 @@
 .hgignore export-ignore
 .hgtags export-ignore
 .gitattributes export-ignore
-python-lib/cuddlefish/_version.py export-subst


### PR DESCRIPTION
`HEAD` commit may move and break download because checksum no longer matches.
https://lists.freebsd.org/pipermail/svn-ports-head/2017-December/162470.html
https://github.com/freebsd/freebsd-ports/commit/ff848a8f769883ddb25fe618d3c45ffd0f8d55bb
https://github.com/freebsd/freebsd-ports/commit/a303135ccb644788bbae676b133a86219cc173ab
