### PR TITLE
Hidden preference to toggle addon version in addon manager

### DIFF
--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -1166,7 +1166,8 @@
           else
             this._icon.src = "";
 
-          if (shouldShowVersionNumber(this.mAddon))
+          if (shouldShowVersionNumber(this.mAddon) && 
+            Services.prefs.getBoolPref("extensions.addonVersionInfo", true))
             this._version.value = this.mAddon.version;
           else
             this._version.hidden = true;


### PR DESCRIPTION
Puts [Show addon version in addon manager addon list](https://github.com/MrAlex94/Waterfox/pull/566) behind user preference, currently on by default.

`extensions.addonVersionInfo`

```javascript
pref("extensions.addonVersionInfo", false);
```

User creates preference in about:config or user.js if changed while page is active simple refresh will update content.