### PR TITLE
Reduce fingerprinting threat by disabling video statistics

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -647,7 +647,7 @@ pref("media.video-queue.default-size", 10);
 pref("media.video-queue.send-to-compositor-size", 9999);
 
 // Whether to disable the video stats to prevent fingerprinting
-pref("media.video_stats.enabled", true);
+sticky_pref("media.video_stats.enabled", false);
 
 // Whether to check the decoder supports recycling.
 pref("media.decoder.recycle.enabled", false);


### PR DESCRIPTION
This pref provides web applications with information about video playback statistics such as the framerate. The fingerprinting threat can be reduced by setting it to false by default. Have yet to notice any adverse effects. More information here:

- https://bugzilla.mozilla.org/show_bug.cgi?id=654550
- https://trac.torproject.org/projects/tor/ticket/15757