### PR TITLE
Stop address shortening, stop implicit outbound.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -342,7 +342,7 @@ pref("browser.urlbar.maxCharsForSearchSuggestions", 20);
 pref("browser.urlbar.suggest.history.onlyTyped",    false);
 
 pref("browser.urlbar.formatting.enabled", true);
-pref("browser.urlbar.trimURLs", true);
+sticky_pref("browser.urlbar.trimURLs", false);
 
 pref("browser.urlbar.oneOffSearches", true);
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -647,7 +647,7 @@ pref("media.video-queue.default-size", 10);
 pref("media.video-queue.send-to-compositor-size", 9999);
 
 // Whether to disable the video stats to prevent fingerprinting
-sticky_pref("media.video_stats.enabled", false);
+pref("media.video_stats.enabled", false);
 
 // Whether to check the decoder supports recycling.
 pref("media.decoder.recycle.enabled", false);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1708,7 +1708,7 @@ pref("network.http.network-changed.timeout", 5);
 
 // The maximum number of current global half open sockets allowable
 // when starting a new speculative connection.
-pref("network.http.speculative-parallel-limit", 6);
+pref("network.http.speculative-parallel-limit", 0);
 
 // Whether or not to block requests for non head js/css items (e.g. media)
 // while those elements load.
@@ -2022,7 +2022,7 @@ pref("network.dns.get-ttl", true);
 pref("network.dnsCacheExpirationGracePeriod", 60);
 
 // This preference can be used to turn off DNS prefetch.
-pref("network.dns.disablePrefetch", false);
+pref("network.dns.disablePrefetch", true);
 
 // This preference controls whether .onion hostnames are
 // rejected before being given to DNS. RFC 7686
@@ -2061,7 +2061,7 @@ pref("network.dir.format", 2);
 
 // enables the prefetch service (i.e., prefetching of <link rel="next"> and
 // <link rel="prefetch"> URLs).
-pref("network.prefetch-next", true);
+pref("network.prefetch-next", false);
 // enables the preloading (i.e., preloading of <link rel="preload"> URLs).
 pref("network.preload", true);
 


### PR DESCRIPTION
network.prefetch-next:
Link prefetching can be used by web sites to give web browsers hints about which pages are likely to be visited so that the browser can download them ahead of time, with the goal of improving performance. There is no same-origin restriction for link prefetching. According to this FAQ, "prefetching will generally cause the cookies of the prefetched site to be accessed".

network.dns.disablePrefetch:
Similar to above, this feature allows Firefox to perform DNS resolution proactively.

network.http.speculative-parallel-limit:
Disable speculative pre-connections.

browser.urlbar.trimURLs:
Stops the address trimming in the address bar, improves the UI, enhances the information given in the URL bar, shows full URL by default (stops unnecessary URL shortening).