### PR TITLE
Free the decoded image buffer before deleting the WebP decoder. 

### DIFF
--- a/image/decoders/nsWebPDecoder.cpp
+++ b/image/decoders/nsWebPDecoder.cpp
@@ -119,6 +119,7 @@ nsWebPDecoder::EndFrame()
        mTimeout.AsEncodedValueDeprecated(), (int)mBlend));
 
   PostFrameStop(opacity, mDisposal, mTimeout, mBlend);
+  WebPFreeDecBuffer(&mBuffer);
   WebPIDelete(mDecoder);
   mDecoder = nullptr;
   mLastRow = 0;


### PR DESCRIPTION
This solves #615 