### PR TITLE
Enable xrender by default.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4883,7 +4883,7 @@ pref("gfx.apitrace.enabled",false);
 
 #ifdef MOZ_X11
 #ifdef MOZ_WIDGET_GTK
-pref("gfx.xrender.enabled",false);
+pref("gfx.xrender.enabled", true);
 pref("widget.chrome.allow-gtk-dark-theme", false);
 pref("widget.content.allow-gtk-dark-theme", false);
 #endif


### PR DESCRIPTION
Resolves perf regressions over remote X.