### PR TITLE
Bug 1398082 - Support compiling stylo with llvm-config-5.0 or llvm-config-6.0

### DIFF
--- a/toolkit/moz.configure
+++ b/toolkit/moz.configure
@@ -643,14 +643,15 @@ def building_stylo_bindgen(stylo_config, bindgen_enabled, compile_environment):
 @imports('os')
 @imports('subprocess')
 def llvm_config_paths(host):
-    llvm_config_progs = [
-        'llvm-config-4.0',
-        'llvm-config-mp-4.0',   # MacPorts' chosen naming scheme.
-        'llvm-config40',
-        'llvm-config-3.9',
-        'llvm-config39',
-        'llvm-config',
-    ]
+    llvm_supported_versions = ['6.0', '5.0', '4.0', '3.9']
+    llvm_config_progs = []
+    for version in llvm_supported_versions:
+        llvm_config_progs += [
+            'llvm-config-%s' % version,
+            'llvm-config-mp-%s' % version,    # MacPorts' chosen naming scheme.
+            'llvm-config%s' % version.replace('.', ''),
+        ]
+    llvm_config_progs.append('llvm-config')
 
     # Homebrew on macOS doesn't make clang available on PATH, so we have to
     # look for it in non-standard places.


### PR DESCRIPTION
`https://bugzilla.mozilla.org/show_bug.cgi?id=1398082`