### PR TITLE
Bug 1314968 - Explicitly specify the AccessPoint interface name. r=kanru

### DIFF
--- a/netwerk/wifi/nsWifiScannerDBus.cpp
+++ b/netwerk/wifi/nsWifiScannerDBus.cpp
@@ -67,7 +67,7 @@ nsWifiScannerDBus::SendMessage(const char* aInterface,
       return NS_ERROR_FAILURE;
     }
   } else if (!strcmp(aFuncCall, "GetAll")) {
-    const char* param = "";
+    const char* param = "org.freedesktop.NetworkManager.AccessPoint";
     if (!dbus_message_iter_append_basic(&argsIter, DBUS_TYPE_STRING, &param)) {
       return NS_ERROR_FAILURE;
     }


### PR DESCRIPTION
The DBus specification allows passing an empty string as the interface to the
org.freedesktop.DBus.Properties.GetAll call to get all properties, throwing away the namespace
(interface) information.

However, GDBus does not allow this. When NetworkManager moved to using GDBus, Firefox lost the
ability to retrieve access points from NetworkManager.

Since we're only interested in properties from the org.freedesktop.NetworkManager.AccessPoint
interface, name it explicitly. This works with both the old and the new NetworkManager.

MozReview-Commit-ID: Kc5HaYvwfRZ

--HG--
extra : rebase_source : e1550d327e5a4ea05b8d35d98ef7b27c0add709b