### PR TITLE
Bug 1371991 - don't link against crmf when building with --with-syste…

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -1927,9 +1927,7 @@ if test -n "$_USE_SYSTEM_NSS"; then
     AM_PATH_NSS(3.32.1, [MOZ_SYSTEM_NSS=1], [AC_MSG_ERROR([you don't have NSS installed or your version is too old])])
 fi
 
-if test -n "$MOZ_SYSTEM_NSS"; then
-   NSS_LIBS="$NSS_LIBS -lcrmf"
-else
+if test -z "$MOZ_SYSTEM_NSS"; then
    NSS_CFLAGS="-I${DIST}/include/nss"
    case "${OS_ARCH}" in
         # Only few platforms have been tested with GYP


### PR DESCRIPTION
…m-nss, r=ted

Differential Revision: https://phabricator.services.mozilla.com/D836

--HG--
extra : rebase_source : 04127ba88296e8bd6849d227641bb0eebae2c23b
extra : amend_source : dde2e35e2d12316950113e5f320d47a914783623