### PR TITLE
Bug 1453127 - Do not use iterators in MediaStreamTrack when removing …

### DIFF
--- a/dom/media/MediaStreamTrack.cpp
+++ b/dom/media/MediaStreamTrack.cpp
@@ -174,11 +174,15 @@ MediaStreamTrack::Destroy()
     mPrincipalHandleListener->Forget();
     mPrincipalHandleListener = nullptr;
   }
-  for (auto l : mTrackListeners) {
-    RemoveListener(l);
+  // Remove all listeners -- avoid iterating over the list we're removing from
+  const nsTArray<RefPtr<MediaStreamTrackListener>> trackListeners(mTrackListeners);
+  for (auto listener : trackListeners) {
+    RemoveListener(listener);
   }
-  for (auto l : mDirectTrackListeners) {
-    RemoveDirectListener(l);
+  // Do the same as above for direct listeners
+  const nsTArray<RefPtr<DirectMediaStreamTrackListener>> directTrackListeners(mDirectTrackListeners);
+  for (auto listener : directTrackListeners) {
+    RemoveDirectListener(listener);
   }
 }
 


### PR DESCRIPTION
…listeners. r=pehrsons a=lizzard

--HG--
extra : source : 6b3aaee40f7507e240da08d6e073cff3c53971f4
extra : intermediate-source : 59e50af7afe19f827dd687ea097d5ba551ab0b1d