### PR TITLE
Be less up-tight about script timeouts.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3133,8 +3133,8 @@ pref("editor.resizing.preserve_ratio",       true);
 pref("editor.positioning.offset",            0);
 
 pref("dom.use_watchdog", true);
-pref("dom.max_chrome_script_run_time", 20);
-pref("dom.max_script_run_time", 10);
+pref("dom.max_chrome_script_run_time", 90);
+pref("dom.max_script_run_time", 20);
 
 // Stop all scripts in a compartment when the "stop script" dialog is used.
 pref("dom.global_stop_script", true);


### PR DESCRIPTION
Especially some chrome scripts need ample time, which is causing issues with background scripts firing when the browser is idle.