### PR TITLE
Don't enforce arbitrary TLS profile.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1722,7 +1722,7 @@ pref("network.http.fast-fallback-to-IPv4", true);
 pref("network.http.spdy.enabled", true);
 pref("network.http.spdy.enabled.http2", true);
 pref("network.http.spdy.enabled.deps", true);
-pref("network.http.spdy.enforce-tls-profile", true);
+pref("network.http.spdy.enforce-tls-profile", false);
 pref("network.http.spdy.chunk-size", 16000);
 pref("network.http.spdy.timeout", 170);
 pref("network.http.spdy.coalesce-hostnames", true);


### PR DESCRIPTION
This prevents people from being unable to visit websites based on "best practice" assumptions.