### PR TITLE
Fix identity.mobilepromo.android URL

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1413,7 +1413,7 @@ pref("identity.sync.tokenserver.uri", "https://token.services.mozilla.com/1.0/sy
 
 // URLs for promo links to mobile browsers. Note that consumers are expected to
 // append a value for utm_campaign.
-pref("identity.mobilepromo.android", "https://play.google.com/store/apps/details?id=org.waterfoxproject.waterfox");
+pref("identity.mobilepromo.android", "https://play.google.com/store/apps/details?id=org.waterfoxproject.waterfox&utm_source=waterfox-browser&utm_medium=waterfox-browser&utm_campaign=");
 pref("identity.mobilepromo.ios", "https://www.mozilla.org/firefox/ios/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=");
 
 // Migrate any existing Firefox Account data from the default profile to the


### PR DESCRIPTION
The link in `about:preferences#sync` is broken right now as a utm_campaign value is appended to it (“consumers are expected to append a value for utm_campaign”). I've added the `utm_` parameters back, just like in the iOS url. Not sure if this would be helpful in the analytics sense, but at the very least the link works again :)