### PR TITLE
Change sponsorship logo and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Waterfox is released under the Mozilla Public License Version 2.0:
 	
 Waterfox binaries are kindly being redistributed free of charge by:
 
- ![MaxCDN](https://raw.githubusercontent.com/MaxCDN/media/master/Screen/maxcdn-logo-full-rgb-300px.png)
+  [<img src="https://s3-us-west-2.amazonaws.com/elof/stackpath-logo-reversed.png" style="width:300px;">](https://www.stackpath.com/?utm_campaign=Partner%20Display&utm_source=Partner%20Display&utm_medium=WaterFox)
 
 From Mozilla's Readme.txt:
 


### PR DESCRIPTION
Hi Waterfox folk, I'm a developer evangelist over at StackPath. We bought MaxCDN a couple years ago and are currently making steps towards consolidating brands. You don't need to make any changes to continue receiving the support we have been and will continue to give you, but we would appreciate if you change the logo and link to reference StackPath when you talk about the sponsorship. If you could also change it on your site that would be greatly appreciated. Let me know if you have any questions or concerns at all.