### PR TITLE
Bug 1420171 don't get the default printer on linux if we're printing to a file

### DIFF
--- a/toolkit/components/printingui/ipc/PrintingParent.cpp
+++ b/toolkit/components/printingui/ipc/PrintingParent.cpp
@@ -142,10 +142,12 @@ PrintingParent::ShowPrintDialog(PBrowserParent* aParent,
   // Requesting the default printer name on Linux has been removed in the child,
   // because it was causing a sandbox violation (see Bug 1329216).
   // If no printer name is set at this point, use the print settings service
-  // to get the default printer name.
-  if (printerName.IsEmpty()) {
-    mPrintSettingsSvc->GetDefaultPrinterName(getter_Copies(printerName));
-    settings->SetPrinterName(printerName);
+  // to get the default printer name, unless we're printing to file.
+  bool printToFile = false;
+  MOZ_ALWAYS_SUCCEEDS(settings->GetPrintToFile(&printToFile));
+  if (!printToFile && printerName.IsEmpty()) {
+      mPrintSettingsSvc->GetDefaultPrinterName(getter_Copies(printerName));
+      settings->SetPrinterName(printerName);
   }
   mPrintSettingsSvc->InitPrintSettingsFromPrinter(printerName, settings);
 #endif

--- a/widget/gtk/nsDeviceContextSpecG.cpp
+++ b/widget/gtk/nsDeviceContextSpecG.cpp
@@ -110,7 +110,7 @@ already_AddRefed<PrintTarget> nsDeviceContextSpecGTK::MakePrintTarget()
   width  /= TWIPS_PER_POINT_FLOAT;
   height /= TWIPS_PER_POINT_FLOAT;
 
-  DO_PR_DEBUG_LOG(("\"%s\", %f, %f\n", mPath, width, height));
+    DO_PR_DEBUG_LOG(("Making PrintTarget: width = %f, height = %f\n", width, height));
   nsresult rv;
 
   // We shouldn't be attempting to get a surface if we've already got a spool

--- a/widget/gtk/nsDeviceContextSpecG.cpp
+++ b/widget/gtk/nsDeviceContextSpecG.cpp
@@ -405,20 +405,26 @@ NS_IMETHODIMP nsPrinterEnumeratorGTK::InitPrintSettingsFromPrinter(const char16_
 
   NS_ENSURE_ARG_POINTER(aPrintSettings);
 
-  /* Set filename */
-  nsAutoCString filename;
-  const char *path;
-  
-  if (!(path = PR_GetEnv("PWD")))
-    path = PR_GetEnv("HOME");
-  
-  if (path)
-    filename = nsPrintfCString("%s/mozilla.pdf", path);
-  else
-    filename.AssignLiteral("mozilla.pdf");
+  // Set a default file name.
+  nsAutoString filename;
+  nsresult rv = aPrintSettings->GetToFileName(filename);
+  if (NS_FAILED(rv) || filename.IsEmpty()) {
+    const char* path = PR_GetEnv("PWD");
+    if (!path) {
+      path = PR_GetEnv("HOME");
+    }
 
-  DO_PR_DEBUG_LOG(("Setting default filename to '%s'\n", filename.get()));
-  aPrintSettings->SetToFileName(NS_ConvertUTF8toUTF16(filename).get());
+    if (path) {
+      CopyUTF8toUTF16(path, filename);
+      filename.AppendLiteral("/mozilla.pdf");
+    } else {
+      filename.AssignLiteral("mozilla.pdf");
+    }
+
+    DO_PR_DEBUG_LOG(("Setting default filename to '%s'\n",
+                     NS_ConvertUTF16toUTF8(filename).get()));
+    aPrintSettings->SetToFileName(filename);
+  }
 
   aPrintSettings->SetIsInitializedFromPrinter(true);
 

--- a/widget/gtk/nsDeviceContextSpecG.h
+++ b/widget/gtk/nsDeviceContextSpecG.h
@@ -46,8 +46,6 @@ protected:
   nsCOMPtr<nsPrintSettingsGTK> mPrintSettings;
   bool mToPrinter : 1;      /* If true, print to printer */
   bool mIsPPreview : 1;     /* If true, is print preview */
-  char   mPath[PATH_MAX];     /* If toPrinter = false, dest file */
-  char   mPrinter[256];       /* Printer name */
   GtkPrintSettings* mGtkPrintSettings;
   GtkPageSetup*     mGtkPageSetup;
 


### PR DESCRIPTION
I think I managed to create a proper branch for this bugfix. The branch contains an exact copy of the fixes from bugzilla 1420171.

https://bugzilla.mozilla.org/show_bug.cgi?id=1420171

This fix is needed to get certain print-to-file  functionality , and for certain addons  (extensions) that print to a file, to work properly.