### PR TITLE
[QOL] Disable the black screen transition when going full-screen

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5010,8 +5010,8 @@ pref("full-screen-api.allow-trusted-requests-only", true);
 pref("full-screen-api.pointer-lock.enabled", true);
 // transition duration of fade-to-black and fade-from-black, unit: ms
 #ifndef MOZ_WIDGET_GTK
-pref("full-screen-api.transition-duration.enter", "200 200");
-pref("full-screen-api.transition-duration.leave", "200 200");
+pref("full-screen-api.transition-duration.enter", "0 0");
+pref("full-screen-api.transition-duration.leave", "0 0");
 #else
 pref("full-screen-api.transition-duration.enter", "0 0");
 pref("full-screen-api.transition-duration.leave", "0 0");


### PR DESCRIPTION
This transition is way too long, and is incredibly irritating.

Me and everyone I know who uses Water/Firefox disables this too.
It would be a great QoL change to get this merged in for default.

Cheers!
 - Josh