### PR TITLE
general.useragent.override.github.com

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -28,6 +28,7 @@ pref("general.useragent.compatMode.firefox", false);
 // This pref exists only for testing purposes. In order to disable all
 // overrides by default, don't initialize UserAgentOverrides.jsm.
 pref("general.useragent.site_specific_overrides", true);
+pref("general.useragent.override.github.com", "Mozilla/5.0 (rv:60.0) Gecko/20100101 Firefox/60.0");
 #ifdef XP_WIN
 pref("general.useragent.override.addons.mozilla.org", "Mozilla/5.0 (Windows NT 10.0; Win64; rv:57.0) Gecko/20100101 Firefox/57.0");
 #endif


### PR DESCRIPTION
To suppress the banner that now appears for Waterfox 56.2.5 (treated as an old unsupported version of Firefox): 

![2018-11-05 23 22 10 issues mralex94-waterfox](https://user-images.githubusercontent.com/192271/48035401-acab9680-e15b-11e8-94f9-7a68a61f9d56.png)

`Mozilla/5.0 (rv:60.0) Gecko/20100101 Firefox/60.0`

- platform agnostic
- 60 (e.g. ESR) is enough to suppress the banner.

https://help.github.com/articles/supported-browsers/