### PR TITLE
Fix the "CraSSh" pure-CSS DoS vulnerability in default configuration

### DIFF
--- a/layout/style/nsCSSParser.cpp
+++ b/layout/style/nsCSSParser.cpp
@@ -1412,6 +1412,9 @@ protected:
 
   // All data from successfully parsed properties are placed into |mData|.
   nsCSSExpandedDataBlock mData;
+  
+  // Value to make sure our resolved variable results stay within sane limits.
+  const int32_t MAX_CSS_VAR_LENGTH = 10240;
 
 public:
   // Used from nsCSSParser constructors and destructors
@@ -2648,6 +2651,12 @@ CSSParserImpl::ResolveValueWithVariableReferencesRec(
             mScanner->StartRecording();
             if (!valid) {
               // Invalid variable with no fallback.
+              return false;
+            }
+            // Make sure we are still using sane sizes for value and
+            // variableValue, and abort if OOB.
+            if (value.Length() > MAX_CSS_VAR_LENGTH ||
+                variableValue.Length() > MAX_CSS_VAR_LENGTH) {
               return false;
             }
             // Valid variable with no fallback.


### PR DESCRIPTION
See https://github.com/MoonchildProductions/UXP/issues/891 and https://cras.sh/ .  I tried the PoC in Waterfox 56.2.5 in a VM, and it totally froze the entire VM!

This pull request is the patch from UXP.  It fixes the issue in Waterfox if `layout.css.servo.enabled` is left at its default value of `false`.  Looks like a separate fix will be needed for the case when `layout.css.servo.enabled` is set to `true`.