### PR TITLE
Add Sortable Folder and Path Columns to the Bookmarks Search

### DIFF
--- a/browser/components/places/content/places.xul
+++ b/browser/components/places/content/places.xul
@@ -396,6 +396,13 @@
             <splitter class="tree-splitter"/>
             <treecol label="&col.lastmodified.label;" id="placesContentLastModified" anonid="lastModified" flex="1" hidden="true"
                       persist="width hidden ordinal sortActive sortDirection"/>
+            <splitter class="tree-splitter"/>
+            <treecol label="&col.parentfolder.label;" id="placesContentParentFolder" anonid="parentFolder" flex="1" hidden="true"
+                      persist="width hidden ordinal sortActive sortDirection"/>
+            <splitter class="tree-splitter"/>
+            <treecol label="&col.parentpath.label;" id="placesContentParentPath" anonid="parentPath" flex="1" hidden="true"
+                      persist="width hidden ordinal sortActive sortDirection"/>
+
           </treecols>
           <treechildren flex="1" onclick="ContentTree.onClick(event);"/>
         </tree>

--- a/browser/components/places/content/treeView.js
+++ b/browser/components/places/content/treeView.js
@@ -582,6 +582,8 @@ PlacesTreeView.prototype = {
   COLUMN_TYPE_DATEADDED: 6,
   COLUMN_TYPE_LASTMODIFIED: 7,
   COLUMN_TYPE_TAGS: 8,
+  COLUMN_TYPE_PARENTFOLDER: 9,
+  COLUMN_TYPE_PARENTPATH: 10,
 
   _getColumnType: function PTV__getColumnType(aColumn) {
     let columnType = aColumn.element.getAttribute("anonid") || aColumn.id;
@@ -603,6 +605,10 @@ PlacesTreeView.prototype = {
         return this.COLUMN_TYPE_LASTMODIFIED;
       case "tags":
         return this.COLUMN_TYPE_TAGS;
+      case "parentFolder":
+        return this.COLUMN_TYPE_PARENTFOLDER;
+      case "parentPath":
+        return this.COLUMN_TYPE_PARENTPATH;
     }
     return this.COLUMN_TYPE_UNKNOWN;
   },
@@ -1555,6 +1561,10 @@ PlacesTreeView.prototype = {
         if (node.lastModified)
           return this._convertPRTimeToString(node.lastModified);
         return "";
+      case this.COLUMN_TYPE_PARENTFOLDER:
+        return node.parentFolder
+      case this.COLUMN_TYPE_PARENTPATH:
+        return node.parentPath
     }
     return "";
   },
@@ -1717,6 +1727,26 @@ PlacesTreeView.prototype = {
           newSort = NHQO.SORT_BY_TAGS_ASCENDING;
 
         break;
+      case this.COLUMN_TYPE_PARENTFOLDER:
+        if (oldSort == NHQO.SORT_BY_PARENTFOLDER_ASCENDING)
+          newSort = NHQO.SORT_BY_PARENTFOLDER_DESCENDING;
+        else if (allowTriState && oldSort == NHQO.SORT_BY_PARENTFOLDER_DESCENDING)
+          newSort = NHQO.SORT_BY_NONE;
+        else
+          newSort = NHQO.SORT_BY_PARENTFOLDER_ASCENDING;
+
+        break;
+      case this.COLUMN_TYPE_PARENTPATH:
+        if (oldSort == NHQO.SORT_BY_PARENTPATH_ASCENDING)
+          newSort = NHQO.SORT_BY_PARENTPATH_DESCENDING;
+        else if (allowTriState && oldSort == NHQO.SORT_BY_PARENTPATH_DESCENDING)
+          newSort = NHQO.SORT_BY_NONE;
+        else
+          newSort = NHQO.SORT_BY_PARENTPATH_ASCENDING;
+
+        break;
+
+
       default:
         throw Cr.NS_ERROR_INVALID_ARG;
     }

--- a/browser/locales/en-US/chrome/browser/places/places.dtd
+++ b/browser/locales/en-US/chrome/browser/places/places.dtd
@@ -84,6 +84,8 @@
 <!ENTITY col.description.label   "Description">
 <!ENTITY col.dateadded.label     "Added">
 <!ENTITY col.lastmodified.label  "Last Modified">
+<!ENTITY col.parentfolder.label  "Parent Folder">
+<!ENTITY col.parentpath.label  "Parent Path">
 
 <!ENTITY search.placeholder  "Search">
 

--- a/toolkit/components/places/nsINavHistoryService.idl
+++ b/toolkit/components/places/nsINavHistoryService.idl
@@ -186,6 +186,11 @@ interface nsINavHistoryResultNode : nsISupports
    * history visit nodes, this value is 0.
    */
   readonly attribute unsigned long visitType;
+
+  readonly attribute AUTF8String parentFolder;
+
+  readonly attribute AUTF8String parentPath;
+
 };
 
 
@@ -1018,8 +1023,12 @@ interface nsINavHistoryQueryOptions : nsISupports
   const unsigned short SORT_BY_TAGS_DESCENDING = 18;
   const unsigned short SORT_BY_ANNOTATION_ASCENDING = 19;
   const unsigned short SORT_BY_ANNOTATION_DESCENDING = 20;
-  const unsigned short SORT_BY_FRECENCY_ASCENDING = 21;
-  const unsigned short SORT_BY_FRECENCY_DESCENDING = 22;
+  const unsigned short SORT_BY_PARENTFOLDER_ASCENDING = 21;
+  const unsigned short SORT_BY_PARENTFOLDER_DESCENDING = 22;
+  const unsigned short SORT_BY_PARENTPATH_ASCENDING = 23;
+  const unsigned short SORT_BY_PARENTPATH_DESCENDING = 24;
+  const unsigned short SORT_BY_FRECENCY_ASCENDING = 25;
+  const unsigned short SORT_BY_FRECENCY_DESCENDING = 26;
 
   /**
    * "URI" results, one for each URI visited in the range. Individual result

--- a/toolkit/components/places/nsNavBookmarks.cpp
+++ b/toolkit/components/places/nsNavBookmarks.cpp
@@ -22,11 +22,11 @@
 using namespace mozilla;
 
 // These columns sit to the right of the kGetInfoIndex_* columns.
-const int32_t nsNavBookmarks::kGetChildrenIndex_Guid = 18;
-const int32_t nsNavBookmarks::kGetChildrenIndex_Position = 19;
-const int32_t nsNavBookmarks::kGetChildrenIndex_Type = 20;
-const int32_t nsNavBookmarks::kGetChildrenIndex_PlaceID = 21;
-const int32_t nsNavBookmarks::kGetChildrenIndex_SyncStatus = 22;
+const int32_t nsNavBookmarks::kGetChildrenIndex_Guid = 20;
+const int32_t nsNavBookmarks::kGetChildrenIndex_Position = 21;
+const int32_t nsNavBookmarks::kGetChildrenIndex_Type = 22;
+const int32_t nsNavBookmarks::kGetChildrenIndex_PlaceID = 23;
+const int32_t nsNavBookmarks::kGetChildrenIndex_SyncStatus = 24;
 
 using namespace mozilla::places;
 
@@ -1126,6 +1126,7 @@ nsNavBookmarks::GetDescendantChildren(int64_t aFolderId,
       "SELECT h.id, h.url, b.title, h.rev_host, h.visit_count, "
              "h.last_visit_date, null, b.id, b.dateAdded, b.lastModified, "
              "b.parent, null, h.frecency, h.hidden, h.guid, null, null, null, "
+             "null, null, "
              "b.guid, b.position, b.type, b.fk, b.syncStatus "
       "FROM moz_bookmarks b "
       "LEFT JOIN moz_places h ON b.fk = h.id "
@@ -2172,6 +2173,7 @@ nsNavBookmarks::QueryFolderChildren(
     "SELECT h.id, h.url, b.title, h.rev_host, h.visit_count, "
            "h.last_visit_date, null, b.id, b.dateAdded, b.lastModified, "
            "b.parent, null, h.frecency, h.hidden, h.guid, null, null, null, "
+           "null, null, "
            "b.guid, b.position, b.type, b.fk "
     "FROM moz_bookmarks b "
     "LEFT JOIN moz_places h ON b.fk = h.id "

--- a/toolkit/components/places/nsNavHistory.cpp
+++ b/toolkit/components/places/nsNavHistory.cpp
@@ -1547,16 +1547,16 @@ PlacesSQLQueryBuilder::SelectAsURI()
             "b2.dateAdded, b2.lastModified, b2.parent, ") +
             tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
                 "null, null, null, "
-                "f.title, null " //TODO Parent Path Query
+                "null, null " //TODO Show Parent Queries in Tag Search
                 ",b2.guid, b2.position, b2.type, b2.fk "
-          "FROM moz_bookmarks f, moz_bookmarks b2 "
+          "FROM moz_bookmarks b2 "
           "JOIN (SELECT b.fk "
                 "FROM moz_bookmarks b "
                 // ADDITIONAL_CONDITIONS will filter on parent.
                 "WHERE b.type = 1 {ADDITIONAL_CONDITIONS} "
                 ") AS seed ON b2.fk = seed.fk "
           "JOIN moz_places h ON h.id = b2.fk "
-          "WHERE f.id = b.parent AND NOT EXISTS ( "
+          "WHERE NOT EXISTS ( "
             "SELECT id FROM moz_bookmarks WHERE id = b2.parent AND parent = ") +
                 nsPrintfCString("%" PRId64, history->GetTagsFolder()) +
           NS_LITERAL_CSTRING(") "

--- a/toolkit/components/places/nsNavHistory.cpp
+++ b/toolkit/components/places/nsNavHistory.cpp
@@ -261,12 +261,14 @@ const int32_t nsNavHistory::kGetInfoIndex_Guid = 14;
 const int32_t nsNavHistory::kGetInfoIndex_VisitId = 15;
 const int32_t nsNavHistory::kGetInfoIndex_FromVisitId = 16;
 const int32_t nsNavHistory::kGetInfoIndex_VisitType = 17;
+const int32_t nsNavHistory::kGetInfoIndex_ParentFolder = 18;
+const int32_t nsNavHistory::kGetInfoIndex_ParentPath = 19;
 // These columns are followed by corresponding constants in nsNavBookmarks.cpp,
 // which must be kept in sync:
-// nsNavBookmarks::kGetChildrenIndex_Guid = 18;
-// nsNavBookmarks::kGetChildrenIndex_Position = 19;
-// nsNavBookmarks::kGetChildrenIndex_Type = 20;
-// nsNavBookmarks::kGetChildrenIndex_PlaceID = 21;
+// nsNavBookmarks::kGetChildrenIndex_Guid = 20;
+// nsNavBookmarks::kGetChildrenIndex_Position = 21;
+// nsNavBookmarks::kGetChildrenIndex_Type = 22;
+// nsNavBookmarks::kGetChildrenIndex_PlaceID = 23;
 
 PLACES_FACTORY_SINGLETON_IMPLEMENTATION(nsNavHistory, gHistoryService)
 
@@ -1517,7 +1519,8 @@ PlacesSQLQueryBuilder::SelectAsURI()
         "SELECT h.id, h.url, h.title AS page_title, h.rev_host, h.visit_count, "
         "h.last_visit_date, null, null, null, null, null, ") +
         tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-        "null, null, null "
+        "null, null, null, "
+        "null,null " 
         "FROM moz_places h "
         // WHERE 1 is a no-op since additonal conditions will start with AND.
         "WHERE 1 "
@@ -1543,15 +1546,17 @@ PlacesSQLQueryBuilder::SelectAsURI()
             "h.rev_host, h.visit_count, h.last_visit_date, null, b2.id, "
             "b2.dateAdded, b2.lastModified, b2.parent, ") +
             tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-            "null, null, null, b2.guid, b2.position, b2.type, b2.fk "
-          "FROM moz_bookmarks b2 "
+                "null, null, null, "
+                "f.title, null " //TODO Parent Path Query
+                ",b2.guid, b2.position, b2.type, b2.fk "
+          "FROM moz_bookmarks f, moz_bookmarks b2 "
           "JOIN (SELECT b.fk "
                 "FROM moz_bookmarks b "
                 // ADDITIONAL_CONDITIONS will filter on parent.
                 "WHERE b.type = 1 {ADDITIONAL_CONDITIONS} "
                 ") AS seed ON b2.fk = seed.fk "
           "JOIN moz_places h ON h.id = b2.fk "
-          "WHERE NOT EXISTS ( "
+          "WHERE f.id = b.parent AND NOT EXISTS ( "
             "SELECT id FROM moz_bookmarks WHERE id = b2.parent AND parent = ") +
                 nsPrintfCString("%" PRId64, history->GetTagsFolder()) +
           NS_LITERAL_CSTRING(") "
@@ -1567,10 +1572,12 @@ PlacesSQLQueryBuilder::SelectAsURI()
             "h.rev_host, h.visit_count, h.last_visit_date, null, b.id, "
             "b.dateAdded, b.lastModified, b.parent, ") +
             tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid,"
-            "null, null, null, b.guid, b.position, b.type, b.fk "
-          "FROM moz_bookmarks b "
+                "null, null, null, "
+                "f.title, null " //TODO Parent Path Query
+                ",b.guid, b.position, b.type, b.fk "
+          "FROM moz_bookmarks f, moz_bookmarks b "
           "JOIN moz_places h ON b.fk = h.id "
-          "WHERE NOT EXISTS "
+          "WHERE f.id = b.parent AND NOT EXISTS "
               "(SELECT id FROM moz_bookmarks "
                 "WHERE id = b.parent AND parent = ") +
                   nsPrintfCString("%" PRId64, history->GetTagsFolder()) +
@@ -1599,7 +1606,8 @@ PlacesSQLQueryBuilder::SelectAsVisit()
     "SELECT h.id, h.url, h.title AS page_title, h.rev_host, h.visit_count, "
       "v.visit_date, null, null, null, null, null, ") +
       tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-      "v.id, v.from_visit, v.visit_type "
+      "v.id, v.from_visit, v.visit_type, "
+      "null, null "
     "FROM moz_places h "
     "JOIN moz_historyvisits v ON h.id = v.place_id "
     // WHERE 1 is a no-op since additonal conditions will start with AND.
@@ -1634,7 +1642,8 @@ PlacesSQLQueryBuilder::SelectAsDay()
      "SELECT null, "
        "'place:type=%d&sort=%d&beginTime='||beginTime||'&endTime='||endTime, "
       "dayTitle, null, null, beginTime, null, null, null, null, null, null, "
-      "null, null, null "
+      "null, null, null, "
+      "null, null "
      "FROM (", // TOUTER BEGIN
      resultType,
      sortingMode);
@@ -1837,7 +1846,8 @@ PlacesSQLQueryBuilder::SelectAsSite()
   mQueryString = nsPrintfCString(
     "SELECT null, 'place:type=%d&sort=%d&domain=&domainIsHost=true'%s, "
            ":localhost, :localhost, null, null, null, null, null, null, null, "
-           "null, null, null "
+           "null, null, null, "
+           "null, null "
     "WHERE EXISTS ( "
       "SELECT h.id FROM moz_places h "
       "%s "
@@ -1852,7 +1862,8 @@ PlacesSQLQueryBuilder::SelectAsSite()
     "SELECT null, "
            "'place:type=%d&sort=%d&domain='||host||'&domainIsHost=true'%s, "
            "host, host, null, null, null, null, null, null, null, "
-           "null, null, null "
+           "null, null, null, "
+           "null, null "
     "FROM ( "
       "SELECT get_unreversed_host(h.rev_host) AS host "
       "FROM moz_places h "
@@ -1892,7 +1903,8 @@ PlacesSQLQueryBuilder::SelectAsTag()
   mQueryString = nsPrintfCString(
     "SELECT null, 'place:folder=' || id || '&queryType=%d&type=%d', "
            "title, null, null, null, null, null, dateAdded, "
-           "lastModified, null, null, null, null, null, null "
+           "lastModified, null, null, null, null, null, null, "
+           "null, null "
     "FROM moz_bookmarks "
     "WHERE parent = %" PRId64,
     nsINavHistoryQueryOptions::QUERY_TYPE_BOOKMARKS,
@@ -2040,6 +2052,18 @@ PlacesSQLQueryBuilder::OrderBy()
     case nsINavHistoryQueryOptions::SORT_BY_ANNOTATION_ASCENDING:
     case nsINavHistoryQueryOptions::SORT_BY_ANNOTATION_DESCENDING:
       break; // Sort later in nsNavHistoryQueryResultNode::FillChildren()
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTFOLDER_ASCENDING:
+        OrderByColumnIndexAsc(nsNavHistory::kGetInfoIndex_ParentFolder);
+      break;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTFOLDER_DESCENDING:
+        OrderByColumnIndexDesc(nsNavHistory::kGetInfoIndex_ParentFolder);
+      break;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTPATH_ASCENDING:
+        OrderByColumnIndexAsc(nsNavHistory::kGetInfoIndex_ParentPath);
+      break;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTPATH_DESCENDING:
+        OrderByColumnIndexDesc(nsNavHistory::kGetInfoIndex_ParentPath);
+      break;
     case nsINavHistoryQueryOptions::SORT_BY_FRECENCY_ASCENDING:
         OrderByColumnIndexAsc(nsNavHistory::kGetInfoIndex_Frecency);
       break;
@@ -2127,7 +2151,8 @@ nsNavHistory::ConstructQueryString(
       "SELECT h.id, h.url, h.title AS page_title, h.rev_host, h.visit_count, h.last_visit_date, "
           "null, null, null, null, null, ") +
           tagsSqlFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-          "null, null, null "
+          "null, null, null, "
+           "null, null "
         "FROM moz_places h "
         "WHERE h.hidden = 0 "
           "AND EXISTS (SELECT id FROM moz_historyvisits WHERE place_id = h.id "
@@ -3833,6 +3858,9 @@ nsNavHistory::RowToResult(mozIStorageValueArray* aRow,
   // itemId
   int64_t itemId = aRow->AsInt64(kGetInfoIndex_ItemId);
   int64_t parentId = -1;
+  nsAutoCString parentFolder,parentPath;
+  parentFolder = "";
+  parentPath = "";
   if (itemId == 0) {
     // This is not a bookmark.  For non-bookmarks we use a -1 itemId value.
     // Notice ids in sqlite tables start from 1, so itemId cannot ever be 0.
@@ -3845,6 +3873,10 @@ nsNavHistory::RowToResult(mozIStorageValueArray* aRow,
       // The Places root has parent == 0, but that item id does not really
       // exist. We want to set the parent only if it's a real one.
       parentId = itemParentId;
+      rv = aRow->GetUTF8String(kGetInfoIndex_ParentFolder, parentFolder);
+      NS_ENSURE_SUCCESS(rv, rv);
+      rv = aRow->GetUTF8String(kGetInfoIndex_ParentPath, parentPath);
+      NS_ENSURE_SUCCESS(rv, rv);
     }
   }
 
@@ -3897,6 +3929,8 @@ nsNavHistory::RowToResult(mozIStorageValueArray* aRow,
     if (itemId != -1) {
       resultNode->mItemId = itemId;
       resultNode->mFolderId = parentId;
+      resultNode->mParentFolder = parentFolder;
+      resultNode->mParentPath = parentPath;
       resultNode->mDateAdded = aRow->AsInt64(kGetInfoIndex_ItemDateAdded);
       resultNode->mLastModified = aRow->AsInt64(kGetInfoIndex_ItemLastModified);
 
@@ -4057,7 +4091,8 @@ nsNavHistory::VisitIdToResultNode(int64_t visitId,
         "SELECT h.id, h.url, h.title, h.rev_host, h.visit_count, "
                "v.visit_date, null, null, null, null, null, "
                ) + tagsFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-              "v.id, v.from_visit, v.visit_type "
+              "v.id, v.from_visit, v.visit_type, "
+              "null, null "
         "FROM moz_places h "
         "JOIN moz_historyvisits v ON h.id = v.place_id "
         "WHERE v.id = :visit_id ")
@@ -4071,7 +4106,8 @@ nsNavHistory::VisitIdToResultNode(int64_t visitId,
         "SELECT h.id, h.url, h.title, h.rev_host, h.visit_count, "
                "h.last_visit_date, null, null, null, null, null, "
                ) + tagsFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-              "null, null, null "
+              "null, null, null, "
+              "null, null "
         "FROM moz_places h "
         "JOIN moz_historyvisits v ON h.id = v.place_id "
         "WHERE v.id = :visit_id ")
@@ -4117,10 +4153,12 @@ nsNavHistory::BookmarkIdToResultNode(int64_t aBookmarkId, nsNavHistoryQueryOptio
              "h.rev_host, h.visit_count, h.last_visit_date, null, b.id, "
              "b.dateAdded, b.lastModified, b.parent, "
              ) + tagsFragment + NS_LITERAL_CSTRING(", h.frecency, h.hidden, h.guid, "
-             "null, null, null, b.guid, b.position, b.type, b.fk "
-      "FROM moz_bookmarks b "
+               "null, null, null, "
+               "f.title, null " //TODO Parent Path Query
+               ",b.guid, b.position, b.type, b.fk "
+      "FROM moz_bookmarks f, moz_bookmarks b "
       "JOIN moz_places h ON b.fk = h.id "
-      "WHERE b.id = :item_id ")
+      "WHERE b.id = :item_id AND f.id = b.parent")
   );
   NS_ENSURE_STATE(stmt);
   mozStorageStatementScoper scoper(stmt);

--- a/toolkit/components/places/nsNavHistory.h
+++ b/toolkit/components/places/nsNavHistory.h
@@ -238,7 +238,8 @@ public:
   static const int32_t kGetInfoIndex_VisitId;
   static const int32_t kGetInfoIndex_FromVisitId;
   static const int32_t kGetInfoIndex_VisitType;
-
+  static const int32_t kGetInfoIndex_ParentFolder;
+  static const int32_t kGetInfoIndex_ParentPath;
   int64_t GetTagsFolder();
 
   // this actually executes a query and gives you results, it is used by

--- a/toolkit/components/places/nsNavHistoryResult.cpp
+++ b/toolkit/components/places/nsNavHistoryResult.cpp
@@ -108,6 +108,8 @@ nsNavHistoryResultNode::nsNavHistoryResultNode(
   mTransitionType(0)
 {
   mTags.SetIsVoid(true);
+  mParentFolder.SetIsVoid(true);
+  mParentPath.SetIsVoid(true);
 }
 
 
@@ -258,6 +260,16 @@ nsNavHistoryResultNode::GetVisitType(uint32_t* aVisitType) {
   *aVisitType = mTransitionType;
   return NS_OK;
 }
+
+NS_IMETHODIMP
+nsNavHistoryResultNode::GetParentFolder(nsACString& aParentFolder){
+  aParentFolder = mParentFolder;
+  return NS_OK; }
+
+NS_IMETHODIMP
+nsNavHistoryResultNode::GetParentPath(nsACString& aParentPath){
+  aParentPath = mParentPath;
+  return NS_OK; }
 
 
 void
@@ -779,6 +791,14 @@ nsNavHistoryContainerResultNode::GetSortingComparator(uint16_t aSortType)
       return &SortComparison_TagsLess;
     case nsINavHistoryQueryOptions::SORT_BY_TAGS_DESCENDING:
       return &SortComparison_TagsGreater;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTFOLDER_ASCENDING:
+      return &SortComparison_ParentFolderLess;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTFOLDER_DESCENDING:
+      return &SortComparison_ParentFolderGreater;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTPATH_ASCENDING:
+      return &SortComparison_ParentPathLess;
+    case nsINavHistoryQueryOptions::SORT_BY_PARENTPATH_DESCENDING:
+      return &SortComparison_ParentPathGreater;
     case nsINavHistoryQueryOptions::SORT_BY_FRECENCY_ASCENDING:
       return &SortComparison_FrecencyLess;
     case nsINavHistoryQueryOptions::SORT_BY_FRECENCY_DESCENDING:
@@ -1296,6 +1316,62 @@ nsNavHistoryContainerResultNode::SortComparison_FrecencyGreater(
 )
 {
   return -nsNavHistoryContainerResultNode::SortComparison_FrecencyLess(a, b, closure);
+}
+
+int32_t nsNavHistoryContainerResultNode::SortComparison_ParentFolderLess(
+    nsNavHistoryResultNode* a, nsNavHistoryResultNode* b, void* closure)
+{
+  uint32_t aType;
+  a->GetType(&aType);
+
+  int32_t value = SortComparison_StringLess(NS_ConvertUTF8toUTF16(a->mParentFolder),
+                                            NS_ConvertUTF8toUTF16(b->mParentFolder));
+  if (value == 0) {
+    // resolve by URI
+    if (a->IsURI()) {
+      value = a->mURI.Compare(b->mURI.get());
+    }
+    if (value == 0) {
+      // resolve by date
+      value = ComparePRTime(a->mTime, b->mTime);
+      if (value == 0)
+        value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+    }
+  }
+  return value;
+}
+int32_t nsNavHistoryContainerResultNode::SortComparison_ParentFolderGreater(
+    nsNavHistoryResultNode* a, nsNavHistoryResultNode* b, void* closure)
+{
+  return -SortComparison_ParentFolderLess(a, b, closure);
+}
+
+int32_t nsNavHistoryContainerResultNode::SortComparison_ParentPathLess(
+    nsNavHistoryResultNode* a, nsNavHistoryResultNode* b, void* closure)
+{
+  uint32_t aType;
+  a->GetType(&aType);
+
+  int32_t value = SortComparison_StringLess(NS_ConvertUTF8toUTF16(a->mParentPath),
+                                            NS_ConvertUTF8toUTF16(b->mParentPath));
+  if (value == 0) {
+    // resolve by URI
+    if (a->IsURI()) {
+      value = a->mURI.Compare(b->mURI.get());
+    }
+    if (value == 0) {
+      // resolve by date
+      value = ComparePRTime(a->mTime, b->mTime);
+      if (value == 0)
+        value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+    }
+  }
+  return value;
+}
+int32_t nsNavHistoryContainerResultNode::SortComparison_ParentPathGreater(
+    nsNavHistoryResultNode* a, nsNavHistoryResultNode* b, void* closure)
+{
+  return -SortComparison_ParentPathLess(a, b, closure);
 }
 
 /**

--- a/toolkit/components/places/nsNavHistoryResult.cpp
+++ b/toolkit/components/places/nsNavHistoryResult.cpp
@@ -1327,15 +1327,19 @@ int32_t nsNavHistoryContainerResultNode::SortComparison_ParentFolderLess(
   int32_t value = SortComparison_StringLess(NS_ConvertUTF8toUTF16(a->mParentFolder),
                                             NS_ConvertUTF8toUTF16(b->mParentFolder));
   if (value == 0) {
-    // resolve by URI
-    if (a->IsURI()) {
-      value = a->mURI.Compare(b->mURI.get());
-    }
-    if (value == 0) {
-      // resolve by date
-      value = ComparePRTime(a->mTime, b->mTime);
-      if (value == 0)
-        value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+    //Compare Folder IDs
+    value = CompareIntegers(a->mFolderId,b->mFolderId);
+    if (value == 0){
+      // resolve by URI
+      if (a->IsURI()) {
+        value = a->mURI.Compare(b->mURI.get());
+      }
+      if (value == 0) {
+        // resolve by date
+        value = ComparePRTime(a->mTime, b->mTime);
+        if (value == 0)
+          value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+      }
     }
   }
   return value;
@@ -1355,19 +1359,24 @@ int32_t nsNavHistoryContainerResultNode::SortComparison_ParentPathLess(
   int32_t value = SortComparison_StringLess(NS_ConvertUTF8toUTF16(a->mParentPath),
                                             NS_ConvertUTF8toUTF16(b->mParentPath));
   if (value == 0) {
-    // resolve by URI
-    if (a->IsURI()) {
-      value = a->mURI.Compare(b->mURI.get());
-    }
-    if (value == 0) {
-      // resolve by date
-      value = ComparePRTime(a->mTime, b->mTime);
-      if (value == 0)
-        value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+    //Compare Folder IDs
+    value = CompareIntegers(a->mFolderId,b->mFolderId);
+    if (value == 0){
+      // resolve by URI
+      if (a->IsURI()) {
+        value = a->mURI.Compare(b->mURI.get());
+      }
+      if (value == 0) {
+        // resolve by date
+        value = ComparePRTime(a->mTime, b->mTime);
+        if (value == 0)
+          value = nsNavHistoryContainerResultNode::SortComparison_Bookmark(a, b, closure);
+      }
     }
   }
   return value;
 }
+
 int32_t nsNavHistoryContainerResultNode::SortComparison_ParentPathGreater(
     nsNavHistoryResultNode* a, nsNavHistoryResultNode* b, void* closure)
 {

--- a/toolkit/components/places/nsNavHistoryResult.h
+++ b/toolkit/components/places/nsNavHistoryResult.h
@@ -251,7 +251,11 @@ NS_DEFINE_STATIC_IID_ACCESSOR(nsNavHistoryResult, NS_NAVHISTORYRESULT_IID)
   NS_IMETHOD GetFromVisitId(int64_t* aFromVisitId) override \
     { return nsNavHistoryResultNode::GetFromVisitId(aFromVisitId); } \
   NS_IMETHOD GetVisitType(uint32_t* aVisitType) override \
-    { return nsNavHistoryResultNode::GetVisitType(aVisitType); }
+    { return nsNavHistoryResultNode::GetVisitType(aVisitType); } \
+  NS_IMETHOD GetParentFolder(nsACString& aParentFolder) override \
+    { return nsNavHistoryResultNode::GetParentFolder(aParentFolder); } \
+  NS_IMETHOD GetParentPath(nsACString& aParentPath) override \
+    { return nsNavHistoryResultNode::GetParentPath(aParentPath); } 
 
 class nsNavHistoryResultNode : public nsINavHistoryResultNode
 {
@@ -278,6 +282,8 @@ public:
   NS_IMETHOD GetVisitId(int64_t* aVisitId) override;
   NS_IMETHOD GetFromVisitId(int64_t* aFromVisitId) override;
   NS_IMETHOD GetVisitType(uint32_t* aVisitType) override;
+  NS_IMETHOD GetParentFolder(nsACString& aParentFolder) override;
+  NS_IMETHOD GetParentPath(nsACString& aParentPath) override;
 
   virtual void OnRemoving();
 
@@ -373,6 +379,8 @@ public:
   int64_t mFromVisitId;
   PRTime mDateAdded;
   PRTime mLastModified;
+  nsCString mParentFolder;
+  nsCString mParentPath;
 
   // The indent level of this node. The root node will have a value of -1.  The
   // root's children will have a value of 0, and so on.
@@ -559,6 +567,22 @@ public:
   static int32_t SortComparison_FrecencyGreater(nsNavHistoryResultNode* a,
                                                 nsNavHistoryResultNode* b,
                                                 void* closure);
+
+  static int32_t SortComparison_ParentFolderLess(nsNavHistoryResultNode* a,
+                                             nsNavHistoryResultNode* b,
+                                             void* closure);
+  static int32_t SortComparison_ParentFolderGreater(nsNavHistoryResultNode* a,
+                                                nsNavHistoryResultNode* b,
+                                                void* closure);
+
+  static int32_t SortComparison_ParentPathLess(nsNavHistoryResultNode* a,
+                                             nsNavHistoryResultNode* b,
+                                             void* closure);
+  static int32_t SortComparison_ParentPathGreater(nsNavHistoryResultNode* a,
+                                                nsNavHistoryResultNode* b,
+                                                void* closure);
+
+
 
   // finding children: THESE DO NOT ADDREF
   nsNavHistoryResultNode* FindChildURI(const nsACString& aSpec,


### PR DESCRIPTION
This pull request aims to solve https://bugzilla.mozilla.org/show_bug.cgi?id=196509 and https://bugzilla.mozilla.org/show_bug.cgi?id=469421 issue. There was an extension for this in the past but since sorting of columns is done on lower level than the extension folder columns were unsortable. 
This extension adds two columns (name of the parent folder and full path of the parent folder) to the bookmarks search which both are sortable. These columns appear empty when there is no search since all shown links are from the same folder. 
I tested these patches in my daily usage with pretty large bookmarks (180k+) and did not see any noticable performance problem or error. 