### PR TITLE
Fix WebRTC build with gcc-8

### DIFF
--- a/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.c
+++ b/media/webrtc/trunk/webrtc/common_audio/vad/vad_core.c
@@ -115,8 +115,9 @@ static int32_t WeightedAverage(int16_t* data, int16_t offset,
 // undefined behavior, so not a good idea; this just makes UBSan ignore the
 // violation, so that our old code can continue to do what it's always been
 // doing.)
-static inline int32_t OverflowingMulS16ByS32ToS32(int16_t a, int32_t b)
-    RTC_NO_SANITIZE("signed-integer-overflow") {
+static inline int32_t RTC_NO_SANITIZE("signed-integer-overflow")
+OverflowingMulS16ByS32ToS32(int16_t a, int32_t b)
+{
   return a * b;
 }
 

--- a/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c
+++ b/media/webrtc/trunk/webrtc/modules/audio_coding/codecs/isac/fix/source/lattice.c
@@ -209,8 +209,9 @@ void WebRtcIsacfix_NormLatticeFilterMa(size_t orderCoef,
 // Left shift of an int32_t that's allowed to overflow. (It's still undefined
 // behavior, so not a good idea; this just makes UBSan ignore the violation, so
 // that our old code can continue to do what it's always been doing.)
-static inline int32_t OverflowingLShiftS32(int32_t x, int shift)
-    RTC_NO_SANITIZE("shift") {
+static inline int32_t RTC_NO_SANITIZE("shift")
+OverflowingLShiftS32(int32_t x, int shift)
+{
   return x << shift;
 }
 


### PR DESCRIPTION
This is the only fix I need to get waterfox built with gcc-8. This has already been added to firefox:

https://hg.mozilla.org/mozilla-central/rev/de196fabad59