### PR TITLE
Fix GMA 950 crash

### DIFF
--- a/gfx/gl/GLContext.cpp
+++ b/gfx/gl/GLContext.cpp
@@ -552,8 +552,6 @@ GLContext::InitWithPrefixImpl(const char* prefix, bool trygl)
     MOZ_ASSERT(majorVer < 10);
     MOZ_ASSERT(minorVer < 10);
     mVersion = majorVer*100 + minorVer*10;
-    if (mVersion < 200)
-        return false;
 
     ////
 


### PR DESCRIPTION
Mozilla added an OpenGL 2.0 check even though it works with 1.4