### PR TITLE
Remove sticky_pref, revert to normal pref.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -656,7 +656,7 @@ pref("media.video-queue.default-size", 10);
 pref("media.video-queue.send-to-compositor-size", 9999);
 
 // Whether to disable the video stats to prevent fingerprinting
-sticky_pref("media.video_stats.enabled", false);
+pref("media.video_stats.enabled", false);
 
 // Whether to check the decoder supports recycling.
 pref("media.decoder.recycle.enabled", false);


### PR DESCRIPTION
No need to make that sticky, normal pref will suffice. Small error on my part.