### PR TITLE
Fix preprocessor directive in about:license

### DIFF
--- a/toolkit/content/license.html
+++ b/toolkit/content/license.html
@@ -84,7 +84,8 @@
       <li><a href="about:license#fuzz-aldrin">fuzz-aldrin License</a></li>
       <li><a href="about:license#hunspell-nl">Dutch Spellchecking Dictionary License</a></li>
 #if defined(XP_WIN) || defined(XP_LINUX)
-      <li><a href="about:license#twemoji">Twemoji License</a></li>#endif
+      <li><a href="about:license#twemoji">Twemoji License</a></li>
+#endif
       <li><a href="about:license#hunspell-ee">Estonian Spellchecking Dictionary License</a></li>
       <li><a href="about:license#expat">Expat License</a></li>
       <li><a href="about:license#firebug">Firebug License</a></li>


### PR DESCRIPTION
Typo was introduced from https://github.com/MrAlex94/Waterfox/pull/781 , someone accidentally deleted a necessary newline.