### PR TITLE
v68: add-ons manager addon versions

### DIFF
--- a/toolkit/mozapps/extensions/content/aboutaddons.js
+++ b/toolkit/mozapps/extensions/content/aboutaddons.js
@@ -1701,15 +1701,19 @@ class AddonCard extends HTMLElement {
 
     // Update the name.
     let name = card.querySelector(".addon-name");
+    let showVersionInName = Services.prefs.getBoolPref("extensions.addonVersionInfo", true);
+    let versionString = this.updateInstall && this.matches('[current-view="updates"] addon-card') ?
+                        this.updateInstall.version : addon.version;
+    let addonNameWithVersion = showVersionInName ? `${addon.name} ${versionString}` : addon.name;
     if (addon.isActive) {
-      name.textContent = addon.name;
+      name.textContent = addonNameWithVersion;
       name.removeAttribute("data-l10n-id");
     } else {
       document.l10n.setAttributes(name, "addon-name-disabled", {
-        name: addon.name,
+        name: addonNameWithVersion,
       });
     }
-    name.title = `${addon.name} ${addon.version}`;
+    name.title = showVersionInName ? addon.name : `${addon.name} ${versionString}`;
 
     // Set the items in the more options menu.
     this.options.update(this, addon, this.updateInstall);

--- a/toolkit/mozapps/extensions/content/extensions.css
+++ b/toolkit/mozapps/extensions/content/extensions.css
@@ -212,3 +212,10 @@ richlistitem:not([selected]) * {
 #pluginFlashBlockingCheckbox .checkbox-label-box {
   display: none; /*see bug 1508724*/
 }
+
+/* Hacky method for smaller window size with addon version */
+@media screen and (max-width: 850px) {
+  .version{
+    display: none;
+  }
+}

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -579,6 +579,7 @@
                 <xul:label anonid="name" class="name" crop="end" flex="1"
                            tooltip="addonitem-tooltip" xbl:inherits="xbl:text=name"/>
                 <xul:label anonid="legacy" class="legacy-warning" value="&addon.legacy.label;" is="text-link"/>
+                <xul:label anonid="version" class="version"/>
                 <xul:label class="disabled-postfix" value="&addon.disabled.postfix;"/>
                 <xul:label class="update-postfix" value="&addon.update.postfix;"/>
                 <xul:spacer flex="5000"/> <!-- Necessary to make the name crop -->
@@ -758,6 +759,9 @@
         document.getAnonymousElementByAttribute(this, "anonid",
                                                 "info");
       </field>
+      <field name="_version">
+        document.getAnonymousElementByAttribute(this, "anonid", "version");
+      </field>
       <field name="_icon">
         document.getAnonymousElementByAttribute(this, "anonid", "icon");
       </field>
@@ -889,6 +893,11 @@
             this._icon.src = iconURL;
           else
             this._icon.src = "";
+
+          if (shouldShowVersionNumber(this.mAddon))
+            this._version.value = this.mAddon.version;
+          else
+            this._version.hidden = true;
 
           if (this.mAddon.description)
             this._description.value = this.mAddon.description;
@@ -1168,6 +1177,14 @@
         ]]></body>
       </method>
 
+      <method name="_updateUpgradeInfo">
+        <body><![CDATA[
+          // Only update the version string if we're displaying the upgrade info
+          if (this.hasAttribute("upgrade") && shouldShowVersionNumber(this.mAddon))
+            this._version.value = this.mManualUpdate.version;
+        ]]></body>
+      </method>
+
       <method name="_fetchReleaseNotes">
         <parameter name="aURI"/>
         <body><![CDATA[
@@ -1417,6 +1434,7 @@
 
           this.mManualUpdate = aInstall;
           this._showStatus("update-available");
+          this._updateUpgradeInfo();
         ]]></body>
       </method>
 
@@ -1603,6 +1621,7 @@
         <xul:vbox class="fade name-outer-container" flex="1">
           <xul:hbox class="name-container">
             <xul:label anonid="name" class="name" crop="end" tooltip="addonitem-tooltip"/>
+            <xul:label anonid="version" class="version" hidden="true"/>
           </xul:hbox>
         </xul:vbox>
         <xul:vbox class="install-status-container">
@@ -1623,6 +1642,9 @@
       </field>
       <field name="_name">
         document.getAnonymousElementByAttribute(this, "anonid", "name");
+      </field>
+      <field name="_version">
+        document.getAnonymousElementByAttribute(this, "anonid", "version");
       </field>
       <field name="_warning">
         document.getAnonymousElementByAttribute(this, "anonid", "warning");
@@ -1651,6 +1673,14 @@
             this._icon.src = this.mAddon.iconURL ||
                              (this.mInstall ? this.mInstall.iconURL : "");
             this._name.value = this.mAddon.name;
+
+            if (this.mAddon.version) {
+              this._version.value = this.mAddon.version;
+              this._version.hidden = false;
+            } else {
+              this._version.hidden = true;
+            }
+
           } else {
             this._icon.src = this.mInstall.iconURL;
             // AddonInstall.name isn't always available - fallback to filename
@@ -1665,6 +1695,13 @@
                           .finalize()
                           .QueryInterface(Ci.nsIURL);
               this._name.value = url.fileName;
+            }
+
+            if (this.mInstall.version) {
+              this._version.value = this.mInstall.version;
+              this._version.hidden = false;
+            } else {
+              this._version.hidden = true;
             }
           }
 

--- a/toolkit/mozapps/extensions/content/extensions.xml
+++ b/toolkit/mozapps/extensions/content/extensions.xml
@@ -894,7 +894,8 @@
           else
             this._icon.src = "";
 
-          if (shouldShowVersionNumber(this.mAddon))
+          if (shouldShowVersionNumber(this.mAddon) && 
+            Services.prefs.getBoolPref("extensions.addonVersionInfo", true))
             this._version.value = this.mAddon.version;
           else
             this._version.hidden = true;


### PR DESCRIPTION
Fixes https://github.com/MrAlex94/Waterfox/issues/1017

While doing the patch for htmlaboutaddons, I noticed that the version numbers in its update list were incorrect _without_ any of these patches - the tooltip was showing the installed version instead of the available update version.  This PR also fixes that bug.