### PR TITLE
v68: regressions from Waterfox 56

### DIFF
--- a/dom/encoding/FallbackEncoding.cpp
+++ b/dom/encoding/FallbackEncoding.cpp
@@ -71,8 +71,7 @@ NotNull<const Encoding*> FallbackEncoding::Get() {
   // Don't let the user break things by setting the override to unreasonable
   // values via about:config
   auto encoding = Encoding::ForLabel(override);
-  if (!encoding || !encoding->IsAsciiCompatible() ||
-      encoding == UTF_8_ENCODING) {
+  if (!encoding || !encoding->IsAsciiCompatible()) {
     mFallback = nullptr;
   } else {
     mFallback = encoding;

--- a/widget/gtk/nsWindow.cpp
+++ b/widget/gtk/nsWindow.cpp
@@ -5293,12 +5293,10 @@ static GdkCursor* get_gtk_cursor(nsCursor aCursor) {
       if (!gdkcursor) newType = MOZ_CURSOR_SPINNING;
       break;
     case eCursor_zoom_in:
-      gdkcursor = gdk_cursor_new_from_name(defaultDisplay, "zoom-in");
-      if (!gdkcursor) newType = MOZ_CURSOR_ZOOM_IN;
+      newType = MOZ_CURSOR_ZOOM_IN;
       break;
     case eCursor_zoom_out:
-      gdkcursor = gdk_cursor_new_from_name(defaultDisplay, "zoom-out");
-      if (!gdkcursor) newType = MOZ_CURSOR_ZOOM_OUT;
+      newType = MOZ_CURSOR_ZOOM_OUT;
       break;
     case eCursor_not_allowed:
       gdkcursor = gdk_cursor_new_from_name(defaultDisplay, "not-allowed");


### PR DESCRIPTION
These fixes were in Waterfox Classic but got dropped in v68.  And Waterfox 68 does need them.

**Allow setting UTF-8 as fallback**

Same patch as https://github.com/MrAlex94/Waterfox/pull/489

**Port 'Revert "Use GTK cursors for zoom-in or zoom-out css cursors (bug 1328724) r=karlt"' to v68**

Fixes https://github.com/MrAlex94/Waterfox/issues/347 for v68 by porting https://github.com/MrAlex94/Waterfox/commit/d5c25411b0838a4578f8a96aa2e09568d900e9b6 .