### PR TITLE
Bug 1554949 - Fix WebRTC build failure with newer linux kernel.

### DIFF
--- a/media/webrtc/trunk/webrtc/rtc_base/physicalsocketserver.cc
+++ b/media/webrtc/trunk/webrtc/rtc_base/physicalsocketserver.cc
@@ -61,6 +61,9 @@ typedef void* SockOptArg;
 #endif  // WEBRTC_POSIX
 
 #if defined(WEBRTC_POSIX) && !defined(WEBRTC_MAC) && !defined(WEBRTC_BSD) && !defined(__native_client__)
+#if defined(WEBRTC_LINUX)
+#include <linux/sockios.h>
+#endif
 
 int64_t GetSocketRecvTimestamp(int socket) {
   struct timeval tv_ioctl;


### PR DESCRIPTION
> Recent kernel commit[1] moved a bit the define for this constant. This revealed
> a missing include in WebRTC.

https://bugzilla.mozilla.org/show_bug.cgi?id=1554949