### PR TITLE
v68: Fix about:preferences

### DIFF
--- a/browser/components/newtab/lib/AboutPreferences.jsm
+++ b/browser/components/newtab/lib/AboutPreferences.jsm
@@ -23,6 +23,17 @@ const PREFS_BEFORE_SECTIONS = [
     },
     icon: "chrome://browser/skin/search-glass.svg",
   },
+  {
+    id: "topsites",
+    pref: {
+      feed: "feeds.topsites",
+      titleString: "settings_pane_topsites_header",
+      descString: "prefs_topsites_description",
+    },
+    icon: "topsites",
+    maxRows: 4,
+    rowsPref: "topSitesRows",
+  },
 ];
 
 // This CSS is added to the whole about:preferences page

--- a/browser/components/preferences/in-content/preferences.js
+++ b/browser/components/preferences/in-content/preferences.js
@@ -121,7 +121,6 @@ function init_all() {
           value: "about:addons",
         });
       });
-    });
 
     document.dispatchEvent(
       new CustomEvent("Initialized", {


### PR DESCRIPTION
**Fix about:preferences**

https://github.com/MrAlex94/Waterfox/commit/090a765e6d7ca41794158191bd216a141d138de1 broke `about:preferences` by adding a stray closing brace and parenthesis to `browser/components/preferences/in-content/preferences.js` :confused: , resulting in only the side panel of `about:preferences` loading, the main settings area was just blank.


**Restore options UI for Top Sites**

Fixes https://github.com/MrAlex94/Waterfox/issues/1107 by reverting relevant part of https://github.com/MrAlex94/Waterfox/commit/28ecee473cb2e855ea116fe8f36342ca51ca486c#diff-ca12ba81c967dce1ca60c6df0494ae4f .
(Tag https://github.com/MrAlex94/Waterfox/issues/979#issuecomment-505255601 )