### PR TITLE
(WF68) No longer trim URLs in WF68, align its behavior with Waterfox 56.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -325,7 +325,7 @@ pref("browser.urlbar.timesBeforeHidingSuggestionsHint", 4);
 pref("browser.urlbar.maxCharsForSearchSuggestions", 20);
 
 pref("browser.urlbar.formatting.enabled", true);
-pref("browser.urlbar.trimURLs", true);
+pref("browser.urlbar.trimURLs", false);
 
 pref("browser.urlbar.oneOffSearches", true);
 


### PR DESCRIPTION
See header.