### PR TITLE
(WF68) Disable sending video stats, anti-fingerprinting measure.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -607,7 +607,7 @@ pref("media.video-queue.default-size", 10);
 pref("media.video-queue.send-to-compositor-size", 9999);
 
 // Whether to disable the video stats to prevent fingerprinting
-pref("media.video_stats.enabled", true);
+pref("media.video_stats.enabled", false);
 
 // Log level for cubeb, the audio input/output system. Valid values are
 // "verbose", "normal" and "" (log disabled).


### PR DESCRIPTION
Disable video statistics, JS performance fingerpriting. Align the behavior of Waterfox 68 with current Waterfox 56.