### PR TITLE
(WF68) Disable battery API, anti-fingerprinting measure.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5283,7 +5283,7 @@ pref("dom.vibrator.max_vibrate_ms", 10000);
 pref("dom.vibrator.max_vibrate_list_len", 128);
 
 // Battery API
-pref("dom.battery.enabled", true);
+pref("dom.battery.enabled", false);
 
 // Push
 


### PR DESCRIPTION
See header. Align the behavior of Waterfox 68 with Waterfox 56.