### PR TITLE
[Waterfox Classic] Update libnestegg from upstream

### DIFF
--- a/media/libnestegg/README_MOZILLA
+++ b/media/libnestegg/README_MOZILLA
@@ -5,4 +5,4 @@ Makefile.in build files for the Mozilla build system.
 
 The nestegg git repository is: https://github.com/kinetiknz/nestegg
 
-The git commit ID used was 89ed0daf2edccb25f744e5faff88b8b4684adceb.
+The git commit ID used was 773adcc29d2c52891421c0b0c10059abf9bc17ea.

--- a/media/libnestegg/include/nestegg.h
+++ b/media/libnestegg/include/nestegg.h
@@ -150,6 +150,30 @@ typedef struct {
   unsigned int crop_left;      /**< Pixels to crop from the left of the frame. */
   unsigned int crop_right;     /**< Pixels to crop from the right of the frame. */
   unsigned int alpha_mode;     /**< 1 if an additional opacity stream is available, otherwise 0. */
+  unsigned int matrix_coefficients;      /**< See Table 4 of ISO/IEC 23001-8:2016. */
+  unsigned int range;                    /**< Clipping of color ranges. */
+  unsigned int transfer_characteristics; /**< See Table 3 of ISO/IEC 23091-4. */
+  unsigned int primaries;                /**< See Table 2 of ISO/IEC 23091-4. */
+  double primary_r_chromacity_x;         /**< Red X chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double primary_r_chromacity_y;         /**< Red Y chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double primary_g_chromacity_x;         /**< Green X chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double primary_g_chromacity_y;         /**< Green Y chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double primary_b_chromacity_x;         /**< Blue X chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double primary_b_chromacity_y;         /**< Blue Y chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double white_point_chromaticity_x;     /**< White X chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double white_point_chromaticity_y;     /**< White Y chromaticity coordinate per CIE 1931.
+                                              NaN means element not present. */
+  double luminance_max;                  /**< Maximum luminance in cd/m2.
+                                              NaN means element not present. */
+  double luminance_min;                  /**< Minimum luminance in cd/m2.
+                                              NaN means element not present. */
 } nestegg_video_params;
 
 /** Parameters specific to an audio track. */
@@ -187,7 +211,7 @@ void nestegg_destroy(nestegg * context);
 int nestegg_duration(nestegg * context, uint64_t * duration);
 
 /** Query the tstamp scale of the media stream in nanoseconds.
-    @note Timecodes presented by nestegg have been scaled by this value
+    @note Timestamps presented by nestegg have been scaled by this value
           before presentation to the caller.
     @param context Stream context initialized by #nestegg_init.
     @param scale   Storage for the queried scale factor.
@@ -366,7 +390,7 @@ int nestegg_packet_has_keyframe(nestegg_packet * packet);
     @retval -1 Error. */
 int nestegg_packet_track(nestegg_packet * packet, unsigned int * track);
 
-/** Query the time stamp in nanoseconds of @a packet.
+/** Query the timestamp in nanoseconds of @a packet.
     @param packet Packet initialized by #nestegg_read_packet.
     @param tstamp Storage for the queried timestamp in nanoseconds.
     @retval  0 Success.


### PR DESCRIPTION
I cloned https://github.com/kinetiknz/nestegg, then updated libnestegg with help of update.sh script.

That fixes problem with playing some movies mentioned on https://bugzilla.mozilla.org/show_bug.cgi?id=1480003.