### PR TITLE
(WF68) Enable the Awesome Bar by default.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -346,7 +346,7 @@ pref("browser.urlbar.usepreloadedtopurls.enabled", false);
 pref("browser.urlbar.usepreloadedtopurls.expire_days", 14);
 
 // Enable the new Address Bar code.
-pref("browser.urlbar.quantumbar", true);
+pref("browser.urlbar.quantumbar", false);
 
 pref("browser.altClickSave", false);
 


### PR DESCRIPTION
Reason: The Awesome Bar uses XUL / XBL, while the Quantum Bar uses web technologies. The Awesome Bar is desirable for Waterfox 68 / Current. Also, it is similar to the Waterfox 56 address bar. Not locking this pref, one may revert to the new Quantum Bar if desired. No difference in functionality.