### PR TITLE
(WF68) Disable the HTML about:addons page by default.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5204,7 +5204,7 @@ pref("extensions.webextensions.enablePerformanceCounters", true);
 pref("extensions.webextensions.performanceCountersMaxAge", 5000);
 
 // The HTML about:addons page.
-pref("extensions.htmlaboutaddons.enabled", true);
+pref("extensions.htmlaboutaddons.enabled", false);
 // Whether to allow the inline options browser in HTML about:addons page.
 pref("extensions.htmlaboutaddons.inline-options.enabled", true);
 // Show recommendations on the extension and theme list views.


### PR DESCRIPTION
Reason: The new design requires more clicks to achieve the same results, the former about:addons page is similar to the one in Waterfox 56, the former about:addons page is also desirable for Waterfox 68 since it is based on XUL / XBL instead of HTML. Not locking this pref, one may revert to the new HTML about:addons page if desired. No difference in functionality.