### PR TITLE
(WF68) Enable playback of encrypted VP9 video in fMP4 container by de…

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1480,7 +1480,7 @@ pref("ui.key.menuAccessKeyFocuses", true);
 #ifdef NIGHTLY_BUILD
 pref("media.eme.vp9-in-mp4.enabled", true);
 #else
-pref("media.eme.vp9-in-mp4.enabled", false);
+pref("media.eme.vp9-in-mp4.enabled", true);
 #endif
 
 pref("media.eme.hdcp-policy-check.enabled", false);


### PR DESCRIPTION
…fault.

This can be enabled by default, as the last blocking bugs have been resolved. See here: https://bugzilla.mozilla.org/show_bug.cgi?id=1554174