### PR TITLE
(WF68) Disable establishing connection to links the mouse hovers over.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1821,7 +1821,7 @@ pref("network.http.network-changed.timeout", 5);
 
 // The maximum number of current global half open sockets allowable
 // when starting a new speculative connection.
-pref("network.http.speculative-parallel-limit", 6);
+pref("network.http.speculative-parallel-limit", 0);
 
 // Whether or not to block requests for non head js/css items (e.g. media)
 // while those elements load.


### PR DESCRIPTION
By default, both Firefox 68 and Waterfox 68 establish connections to linked servers once the user hovers over the related link with the mouse or trackpad. This is problematic from a privacy perspective, as hovering over a link is not the same as actually clicking a link, since the user doesn't give explicit consent to visit the related website by just hovering over a link. This being enabled by default is also problematic from a legal perspective, since the user might accidentally establish a connection to a website with illegal content without ever having actually visited such a website. This was implemented for performance reasons, but the benefit is negligible at best - and is often nullified, as users don't visit most of the links they hover over. Please consider disabling this by merging this commit for a) privacy reasons and to b) protect users from a legalistic point of view.