### PR TITLE
[current] Disable some telemetry settings

### DIFF
--- a/modules/libpref/Preferences.cpp
+++ b/modules/libpref/Preferences.cpp
@@ -3334,18 +3334,10 @@ static Maybe<bool> TelemetryPrefValue() {
     return Nothing();
   }
 
-  // Determine the correct default for toolkit.telemetry.enabled. If this
-  // build has MOZ_TELEMETRY_ON_BY_DEFAULT *or* we're on the beta channel,
-  // telemetry is on by default, otherwise not. This is necessary so that
-  // beta users who are testing final release builds don't flipflop defaults.
-#  ifdef MOZ_TELEMETRY_ON_BY_DEFAULT
-  return Some(true);
-#  else
-  nsAutoCString channelPrefValue;
-  Unused << Preferences::GetCString(kChannelPref, channelPrefValue,
-                                    PrefValueKind::Default);
-  return Some(channelPrefValue.EqualsLiteral("beta"));
-#  endif
+  // Determine the correct default for toolkit.telemetry.enabled
+
+  // Waterfox doesn't do telemetry
+  return Some(false);
 }
 
 /* static */
@@ -3366,32 +3358,7 @@ static bool TelemetryPrefValue() {
   // toolkit.telemetry.enabled determines whether we send "extended" data.
   // We only want extended data from pre-release channels due to size.
 
-  NS_NAMED_LITERAL_CSTRING(channel, MOZ_STRINGIFY(MOZ_UPDATE_CHANNEL));
-
-  // Easy cases: Nightly, Aurora, Beta.
-  if (channel.EqualsLiteral("nightly") || channel.EqualsLiteral("aurora") ||
-      channel.EqualsLiteral("beta")) {
-    return true;
-  }
-
-#  ifndef MOZILLA_OFFICIAL
-  // Local developer builds: non-official builds on the "default" channel.
-  if (channel.EqualsLiteral("default")) {
-    return true;
-  }
-#  endif
-
-  // Release Candidate builds: builds that think they are release builds, but
-  // are shipped to beta users.
-  if (channel.EqualsLiteral("release")) {
-    nsAutoCString channelPrefValue;
-    Unused << Preferences::GetCString(kChannelPref, channelPrefValue,
-                                      PrefValueKind::Default);
-    if (channelPrefValue.EqualsLiteral("beta")) {
-      return true;
-    }
-  }
-
+  // Waterfox doesn't do telemetry
   return false;
 }
 

--- a/toolkit/components/telemetry/app/TelemetryUtils.jsm
+++ b/toolkit/components/telemetry/app/TelemetryUtils.jsm
@@ -266,24 +266,8 @@ var TelemetryUtils = {
    * Set the Telemetry core recording flag for Unified Telemetry.
    */
   setTelemetryRecordingFlags() {
-    // Enable extended Telemetry on pre-release channels and disable it
-    // on Release/ESR.
-    let prereleaseChannels = ["nightly", "aurora", "beta"];
-    if (!AppConstants.MOZILLA_OFFICIAL) {
-      // Turn extended telemetry for local developer builds.
-      prereleaseChannels.push("default");
-    }
-    const isPrereleaseChannel = prereleaseChannels.includes(
-      AppConstants.MOZ_UPDATE_CHANNEL
-    );
-    const isReleaseCandidateOnBeta =
-      AppConstants.MOZ_UPDATE_CHANNEL === "release" &&
-      Services.prefs.getCharPref("app.update.channel", null) === "beta";
-    Services.telemetry.canRecordBase = true;
-    Services.telemetry.canRecordExtended =
-      isPrereleaseChannel ||
-      isReleaseCandidateOnBeta ||
-      Services.prefs.getBoolPref(this.Preferences.OverridePreRelease, false);
+    Services.telemetry.canRecordBase = false;
+    Services.telemetry.canRecordExtended = false;
   },
 
   /**


### PR DESCRIPTION
In https://old.reddit.com/r/waterfox/comments/dib6iq/why_is_the_pref_for_telemetry_locked_to_enabled/ it was pointed out that `toolkit.telemetry.enabled` is locked to `true` in Waterfox Current.  I checked and saw the same, so I looked into this, and it turns out Waterfox was indeed collecting telemetry (only locally, not sending it anywhere).

This patch flips the value of `toolkit.telemetry.enabled` to `false` along with a couple other internal telemetry settings I found while investigating.  And based on comparing `about:telemetry` in builds before and after this patch, I think this also disables telemetry collection.