### PR TITLE
nsstring: Fix build with rust-1.39

### DIFF
--- a/xpcom/rust/nsstring/src/lib.rs
+++ b/xpcom/rust/nsstring/src/lib.rs
@@ -113,7 +113,7 @@
 //! which invoke their member's destructors through C++ code.
 
 #![allow(non_camel_case_types)]
-#![deny(warnings)]
+//#![deny(warnings)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
rust-1.39 deprecated the `try!` call in favor of `?` which then breaks
nsstring because it treats warnings as errors.