### PR TITLE
[Current] Add another improvements and fixes (part 2)

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1928,3 +1928,6 @@ pref("browser.preferences.useAllNew", false);
 
 // Disable extensions recommendations
 pref("extensions.getAddons.showPane", false);
+
+// Window controls position
+pref("browser.windowControls.position", "right");

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1936,3 +1936,6 @@ pref("browser.windowControls.position", "right");
 // 0 - Menu Icon
 // 1 - Browser Icon
 pref("browser.menuIcon.style", 0);
+
+// Bookmarks Toolbar Position
+pref("browser.bookmarksBar.position", "top");

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1931,3 +1931,8 @@ pref("extensions.getAddons.showPane", false);
 
 // Window controls position
 pref("browser.windowControls.position", "right");
+
+// Menu Icon Style
+// 0 - Menu Icon
+// 1 - Browser Icon
+pref("browser.menuIcon.style", 0);

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -1929,6 +1929,10 @@ var gBrowserInit = {
       moveWindowControls();
     }
 
+    if (Services.prefs.getIntPref("browser.menuIcon.style") == 1) {
+      changeMenuIconStyle();
+    }
+
     this._loadHandled = true;
   },
 

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -1933,6 +1933,10 @@ var gBrowserInit = {
       changeMenuIconStyle();
     }
 
+    if (Services.prefs.getStringPref("browser.bookmarksBar.position") == "bottom") {
+      moveBookmarksBar();
+    }
+
     this._loadHandled = true;
   },
 

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -1925,6 +1925,10 @@ var gBrowserInit = {
       moveTabBar();
     }
 
+    if(Services.prefs.getStringPref("browser.windowControls.position") == "left"){
+      moveWindowControls();
+    }
+
     this._loadHandled = true;
   },
 

--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -690,8 +690,27 @@
   <box id="appMenu-viewCache" hidden="true"/>
 
   <toolbox id="navigator-toolbox">
+#include titlebar-items.inc.xul
+  <html:div id="window-controls" hidden="true" pack="end" skipintoolbarset="true"
+            ordinal="1000">
+    <toolbarbutton id="minimize-button"
+                       tooltiptext="&fullScreenMinimize.tooltip;"
+                       oncommand="window.minimize();"/>
 
-    <vbox id="titlebar">
+    <toolbarbutton id="restore-button"
+#ifdef XP_MACOSX
+# Prior to 10.7 there wasn't a native fullscreen button so we use #restore-button
+# to exit fullscreen and want it to behave like other toolbar buttons.
+                       class="toolbarbutton-1"
+#endif
+                       tooltiptext="&fullScreenRestore.tooltip;"
+                       oncommand="BrowserFullScreen();"/>
+
+    <toolbarbutton id="close-button"
+                       tooltiptext="&fullScreenClose.tooltip;"
+                       oncommand="BrowserTryToCloseWindow();"/>
+  </html:div>
+    <vbox id="titlebar" class="tabs-topAboveAB">
       <!-- Menu -->
       <toolbar type="menubar" id="toolbar-menubar"
                class="browser-toolbar chromeclass-menubar titlebar-color"
@@ -708,8 +727,6 @@
 # shared with other top level windows in macWindow.inc.xul.
 #include browser-menubar.inc
         </toolbaritem>
-        <spacer flex="1" skipintoolbarset="true" ordinal="1000"/>
-#include titlebar-items.inc.xul
       </toolbar>
 
       <toolbar id="TabsToolbar"
@@ -763,8 +780,6 @@
                 aria-live="polite"/>
         <hbox class="private-browsing-indicator"/>
 #endif
-
-#include titlebar-items.inc.xul
 
 #ifdef XP_MACOSX
         <!-- OS X does not natively support RTL for its titlebar items, so we prevent this secondary
@@ -1087,26 +1102,6 @@
                        label="&brandShortName;"
                        tooltiptext="&appmenu.tooltip;"/>
       </toolbaritem>
-
-      <hbox id="window-controls" hidden="true" pack="end" skipintoolbarset="true"
-            ordinal="1000">
-        <toolbarbutton id="minimize-button"
-                       tooltiptext="&fullScreenMinimize.tooltip;"
-                       oncommand="window.minimize();"/>
-
-        <toolbarbutton id="restore-button"
-#ifdef XP_MACOSX
-# Prior to 10.7 there wasn't a native fullscreen button so we use #restore-button
-# to exit fullscreen and want it to behave like other toolbar buttons.
-                       class="toolbarbutton-1"
-#endif
-                       tooltiptext="&fullScreenRestore.tooltip;"
-                       oncommand="BrowserFullScreen();"/>
-
-        <toolbarbutton id="close-button"
-                       tooltiptext="&fullScreenClose.tooltip;"
-                       oncommand="BrowserTryToCloseWindow();"/>
-      </hbox>
 
       <box id="library-animatable-box" class="toolbarbutton-animatable-box">
         <image class="toolbarbutton-animatable-image"/>

--- a/browser/base/content/titlebar-items.inc.xul
+++ b/browser/base/content/titlebar-items.inc.xul
@@ -2,10 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-<hbox class="titlebar-buttonbox-container" skipintoolbarset="true">
-  <hbox class="titlebar-buttonbox titlebar-color">
+<html:div class="titlebar-buttonbox-container" skipintoolbarset="true">
+  <html:div class="titlebar-buttonbox titlebar-color">
     <toolbarbutton class="titlebar-button titlebar-min" oncommand="window.minimize();"/>
     <toolbarbutton class="titlebar-button titlebar-max" oncommand="onTitlebarMaxClick();"/>
     <toolbarbutton class="titlebar-button titlebar-close" command="cmd_closeWindow"/>
-  </hbox>
-</hbox>
+  </html:div>
+</html:div>

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -1300,30 +1300,41 @@ function showBtnRange() {
 
 function moveTabBar()
 {
+  var bottomBookmarksBar = windowRoot.ownerGlobal.document.querySelector("#browser-bottombox #PersonalToolbar");
+  var tabsToolbar = windowRoot.ownerGlobal.document.querySelector("#TabsToolbar");
+  var titlebar = windowRoot.ownerGlobal.document.querySelector("#titlebar");
+
   if(Services.prefs.getStringPref("browser.tabBar.position") == "topUnderAB")
   {
-    windowRoot.ownerGlobal.document.querySelector("#navigator-toolbox").appendChild(windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
+    windowRoot.ownerGlobal.document.querySelector("#navigator-toolbox").appendChild(tabsToolbar);
     windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
-    if (windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB"))
+    if (titlebar.classList.contains("tabs-topAboveAB"))
     {
-      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.remove("tabs-topAboveAB");
+      titlebar.classList.remove("tabs-topAboveAB");
     }
   }
   else if (Services.prefs.getStringPref("browser.tabBar.position") == "bottom")
   {
-    windowRoot.ownerGlobal.document.querySelector("#browser-bottombox").insertAdjacentElement('afterbegin', windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
-    windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
-    if (windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB"))
+    if(bottomBookmarksBar)
     {
-      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.remove("tabs-topAboveAB");
+      bottomBookmarksBar.insertAdjacentElement('afterend', tabsToolbar);
+    }
+    else
+    {
+      windowRoot.ownerGlobal.document.querySelector("#browser-bottombox").insertAdjacentElement('afterbegin', tabsToolbar);
+    }
+    windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
+    if (titlebar.classList.contains("tabs-topAboveAB"))
+    {
+      titlebar.classList.remove("tabs-topAboveAB");
     }
   }
   else if (Services.prefs.getStringPref("browser.tabBar.position") == "topAboveAB")
   {
-    windowRoot.ownerGlobal.document.querySelector("#titlebar").insertAdjacentElement('beforeend', windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
+    titlebar.insertAdjacentElement('beforeend', tabsToolbar);
     windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
-    if (!windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB")) {
-      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.add("tabs-topAboveAB");
+    if (!titlebar.classList.contains("tabs-topAboveAB")) {
+      titlebar.classList.add("tabs-topAboveAB");
     }
  }
 }
@@ -1352,5 +1363,23 @@ function changeMenuIconStyle() {
   }
   else if (Services.prefs.getIntPref("browser.menuIcon.style") == 1) {
     menuBtn.classList.add("browser");
+  }
+}
+
+function moveBookmarksBar() {
+  var bottomTabs = windowRoot.ownerGlobal.document.querySelector("#browser-bottombox #TabsToolbar");
+  var bookmarksBar = windowRoot.ownerGlobal.document.querySelector("#PersonalToolbar");
+
+  if (Services.prefs.getStringPref("browser.bookmarksBar.position") == "top") {
+    windowRoot.ownerGlobal.document.querySelector("#nav-bar").insertAdjacentElement('afterend', bookmarksBar);
+  }
+  else if (Services.prefs.getStringPref("browser.bookmarksBar.position") == "bottom") {
+    if(bottomTabs) {
+      bottomTabs.insertAdjacentElement('beforebegin', bookmarksBar);
+    }
+    else
+    {
+      windowRoot.ownerGlobal.document.querySelector("#browser-bottombox").insertAdjacentElement('afterbegin', bookmarksBar);
+    }
   }
 }

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -1327,3 +1327,18 @@ function moveTabBar()
     }
  }
 }
+
+function moveWindowControls() {
+  if(Services.prefs.getStringPref("browser.windowControls.position") == "left")
+  {
+    windowRoot.ownerGlobal.document.querySelector(".titlebar-buttonbox").classList.add("left");
+    windowRoot.ownerGlobal.document.querySelector("#window-controls").classList.add("left");
+    windowRoot.ownerGlobal.document.querySelector("#TabsToolbar").classList.add("leftWindowControls");
+  }
+  else
+  {
+    windowRoot.ownerGlobal.document.querySelector(".titlebar-buttonbox").classList.remove("left");
+    windowRoot.ownerGlobal.document.querySelector("#window-controls").classList.remove("left");
+    windowRoot.ownerGlobal.document.querySelector("#TabsToolbar").classList.remove("leftWindowControls");
+  }
+}

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -1342,3 +1342,15 @@ function moveWindowControls() {
     windowRoot.ownerGlobal.document.querySelector("#TabsToolbar").classList.remove("leftWindowControls");
   }
 }
+
+function changeMenuIconStyle() {
+  var menuBtn = windowRoot.ownerGlobal.document.querySelector("#PanelUI-menu-button");
+  if (Services.prefs.getIntPref("browser.menuIcon.style") == 0) {
+    if (menuBtn.classList.contains("browser")) {
+      menuBtn.classList.remove("browser");
+    }
+  }
+  else if (Services.prefs.getIntPref("browser.menuIcon.style") == 1) {
+    menuBtn.classList.add("browser");
+  }
+}

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -1304,15 +1304,26 @@ function moveTabBar()
   {
     windowRoot.ownerGlobal.document.querySelector("#navigator-toolbox").appendChild(windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
     windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
+    if (windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB"))
+    {
+      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.remove("tabs-topAboveAB");
+    }
   }
   else if (Services.prefs.getStringPref("browser.tabBar.position") == "bottom")
   {
     windowRoot.ownerGlobal.document.querySelector("#browser-bottombox").insertAdjacentElement('afterbegin', windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
     windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
+    if (windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB"))
+    {
+      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.remove("tabs-topAboveAB");
+    }
   }
   else if (Services.prefs.getStringPref("browser.tabBar.position") == "topAboveAB")
   {
-    windowRoot.ownerGlobal.document.querySelector("#titlebar").insertAdjacentElement('afterend', windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
+    windowRoot.ownerGlobal.document.querySelector("#titlebar").insertAdjacentElement('beforeend', windowRoot.ownerGlobal.document.querySelector("#TabsToolbar"));
     windowRoot.ownerGlobal.gBrowser.setTabTitle(windowRoot.ownerGlobal.document.querySelector(".tabbrowser-tab[first-visible-tab]"));
-  }
+    if (!windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.contains("tabs-topAboveAB")) {
+      windowRoot.ownerGlobal.document.querySelector("#titlebar").classList.add("tabs-topAboveAB");
+    }
+ }
 }

--- a/browser/base/content/utilityOverlay.js
+++ b/browser/base/content/utilityOverlay.js
@@ -1246,54 +1246,64 @@ function resetZoomStatus() {
 
 
 function updateZoomStatus() {
-  var zoomValue =  windowRoot.ownerGlobal.ZoomManager.getZoomForBrowser(windowRoot.ownerGlobal.gBrowser)
+  var zoomValue =  windowRoot.ownerGlobal.ZoomManager.getZoomForBrowser(windowRoot.ownerGlobal.gBrowser);
+  var resetZoomBtn = windowRoot.ownerGlobal.document.querySelector('.reset-zoom.button-textonly');
   windowRoot.ownerGlobal.document.querySelector('#zoom-range-status').value = zoomValue;
   var zoomPercentValue = parseInt(zoomValue * 100);
   windowRoot.ownerGlobal.document.querySelector('.zoom-percent-status').textContent = zoomPercentValue +' %';
   if (zoomPercentValue != 100){
-    windowRoot.ownerGlobal.document.querySelector('.reset-zoom.button-textonly').disabled = "";
+    resetZoomBtn.disabled = "";
   }
   else
   {
-    windowRoot.ownerGlobal.document.querySelector('.reset-zoom.button-textonly').disabled = "true";
+    resetZoomBtn.disabled = "true";
   }
 }
 
 function toggleStatusBar() {
+  var statuspanel = windowRoot.ownerGlobal.document.getElementById("statuspanel");
+  var statusbar = windowRoot.ownerGlobal.document.querySelector(".toolbar-statusbar");
+  var zoombtn = windowRoot.ownerGlobal.document.querySelector("#urlbar-zoom-button");
+  var pageActionSeparator = windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator");
+
   if (Services.prefs.getIntPref("browser.statusbar.mode") == 2) {
-    windowRoot.ownerGlobal.document.getElementById("statuspanel").hidden = true;
-    windowRoot.ownerGlobal.document.querySelector(".toolbar-statusbar").style.display = "flex";
-    windowRoot.ownerGlobal.document.querySelector("#urlbar-zoom-button").style.display = "none";
-    windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator").style.display = "none";
+    statuspanel.hidden = true;
+    statusbar.style.display = "flex";
+    zoombtn.style.display = "none";
+    pageActionSeparator.style.display = "none";
   }
   else if (Services.prefs.getIntPref("browser.statusbar.mode") == 1) {
-    windowRoot.ownerGlobal.document.querySelector(".toolbar-statusbar").style.display = "none";
-    windowRoot.ownerGlobal.document.querySelector("#urlbar-zoom-button").style.display = "";
-    windowRoot.ownerGlobal.document.getElementById("statuspanel").hidden = "";
-    windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator").style.display = "";
-    windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator").style.visibility = "visible";
+    statusbar.style.display = "none";
+    zoombtn.style.display = "";
+    statuspanel.hidden = "";
+    pageActionSeparator.style.display = "";
+    pageActionSeparator.style.visibility = "visible";
   }
   else if (Services.prefs.getIntPref("browser.statusbar.mode") == 0) {
-    windowRoot.ownerGlobal.document.querySelector(".toolbar-statusbar").style.display = "none";
-    windowRoot.ownerGlobal.document.getElementById("statuspanel").hidden = true;
-    windowRoot.ownerGlobal.document.querySelector("#urlbar-zoom-button").style.display = "";
-    windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator").style.display = "";
-    windowRoot.ownerGlobal.document.querySelector("#pageActionSeparator").style.visibility = "visible";
+    statusbar.style.display = "none";
+    statuspanel.hidden = true;
+    zoombtn.style.display = "";
+    pageActionSeparator.style.display = "";
+    pageActionSeparator.style.visibility = "visible";
   }
 }
 
 function showBtnRange() {
+  var zoomoutsb = windowRoot.ownerGlobal.document.querySelector("#zoomoutsb");
+  var zoominsb = windowRoot.ownerGlobal.document.querySelector("#zoominsb");
+  var zoomStatus = windowRoot.ownerGlobal.document.querySelector("#zoom-range-status");
+
   if (Services.prefs.getIntPref("browser.statusbar.mode") == 2) {
     if(Services.prefs.getBoolPref("browser.statusbar.showbtn", true)) {
-      windowRoot.ownerGlobal.document.querySelector("#zoomoutsb").style.display = "initial";
-      windowRoot.ownerGlobal.document.querySelector("#zoominsb").style.display = "initial";
-      windowRoot.ownerGlobal.document.querySelector("#zoom-range-status").style.display = "none";
+      zoomoutsb.style.display = "initial";
+      zoominsb.style.display = "initial";
+      zoomStatus.style.display = "none";
     }
     else
     {
-      windowRoot.ownerGlobal.document.querySelector("#zoomoutsb").style.display = "none";
-      windowRoot.ownerGlobal.document.querySelector("#zoominsb").style.display = "none";
-      windowRoot.ownerGlobal.document.querySelector("#zoom-range-status").style.display = "initial";
+      zoomoutsb.style.display = "none";
+      zoominsb.style.display = "none";
+      zoomStatus.style.display = "initial";
     }
   }
 }
@@ -1340,17 +1350,21 @@ function moveTabBar()
 }
 
 function moveWindowControls() {
+  var titlebarButtonbox =  windowRoot.ownerGlobal.document.querySelector(".titlebar-buttonbox");
+  var windowControls = windowRoot.ownerGlobal.document.querySelector("#window-controls");
+  var tabsToolbar = windowRoot.ownerGlobal.document.querySelector("#TabsToolbar");
+
   if(Services.prefs.getStringPref("browser.windowControls.position") == "left")
   {
-    windowRoot.ownerGlobal.document.querySelector(".titlebar-buttonbox").classList.add("left");
-    windowRoot.ownerGlobal.document.querySelector("#window-controls").classList.add("left");
-    windowRoot.ownerGlobal.document.querySelector("#TabsToolbar").classList.add("leftWindowControls");
+    titlebarButtonbox.classList.add("left");
+    windowControls.classList.add("left");
+    tabsToolbar.classList.add("leftWindowControls");
   }
   else
   {
-    windowRoot.ownerGlobal.document.querySelector(".titlebar-buttonbox").classList.remove("left");
-    windowRoot.ownerGlobal.document.querySelector("#window-controls").classList.remove("left");
-    windowRoot.ownerGlobal.document.querySelector("#TabsToolbar").classList.remove("leftWindowControls");
+    titlebarButtonbox.classList.remove("left");
+    windowControls.classList.remove("left");
+    tabsToolbar.classList.remove("leftWindowControls");
   }
 }
 

--- a/browser/components/preferences/in-content-all-new/appearance.js
+++ b/browser/components/preferences/in-content-all-new/appearance.js
@@ -20,6 +20,10 @@ Preferences.addAll([
 
   // Window Controls Position
   { id: "browser.windowControls.position", type: "wstring" },
+
+  // Menu Icon Style
+  { id: "browser.menuIcon.style", type: "int" },
+
 ]);
 
 var gAppearancePane = {

--- a/browser/components/preferences/in-content-all-new/appearance.js
+++ b/browser/components/preferences/in-content-all-new/appearance.js
@@ -24,6 +24,9 @@ Preferences.addAll([
   // Menu Icon Style
   { id: "browser.menuIcon.style", type: "int" },
 
+  // Bookmarks Toolbar Position
+  { id: "browser.bookmarksBar.position", type: "wstring" },
+
 ]);
 
 var gAppearancePane = {

--- a/browser/components/preferences/in-content-all-new/appearance.js
+++ b/browser/components/preferences/in-content-all-new/appearance.js
@@ -17,6 +17,9 @@ Preferences.addAll([
   // Status Bar
   { id: "browser.statusbar.mode", type: "int" },
   { id: "browser.statusbar.showbtn", type: "bool" },
+
+  // Window Controls Position
+  { id: "browser.windowControls.position", type: "wstring" },
 ]);
 
 var gAppearancePane = {
@@ -25,6 +28,16 @@ var gAppearancePane = {
         Services.obs.notifyObservers(window, "appearance-pane-loaded");
 
         this.setInitialized();
+    },
+    toggleMoveWindowControls() {
+      if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", true))
+      {
+        document.getElementById("windowControlsRadioGroup").disabled = "";
+      }
+      else
+      {
+        document.getElementById("windowControlsRadioGroup").disabled = "true";
+      }
     }
 };
 

--- a/browser/components/preferences/in-content-all-new/appearance.xul
+++ b/browser/components/preferences/in-content-all-new/appearance.xul
@@ -66,4 +66,17 @@
     </radiogroup>
 </groupbox>
 
+<!-- Menu Icon Style preferences -->
+<groupbox id="menuIconStyleGroup"
+          data-category="paneAppearance"
+          hidden="true">
+  <label><html:h2 data-l10n-id="menu-icon-style-header"/></label>
+    <radiogroup id="menuIconStyleRadioGroup" preference="browser.menuIcon.style" onsyncfrompreference="changeMenuIconStyle();">
+      <radio value="0"
+             data-l10n-id="menu-icon"/>
+      <radio value="1"
+             data-l10n-id="browser-icon"/>
+    </radiogroup>
+</groupbox>
+
 </html:template>

--- a/browser/components/preferences/in-content-all-new/appearance.xul
+++ b/browser/components/preferences/in-content-all-new/appearance.xul
@@ -53,4 +53,17 @@
   </vbox>
 </groupbox>
 
+<!-- Window Controls Position preferences -->
+<groupbox id="windowControlsGroup"
+          data-category="paneAppearance"
+          hidden="true">
+  <label><html:h2 data-l10n-id="window-controls-position-header"/></label>
+    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gAppearancePane.toggleMoveWindowControls(); moveWindowControls();">
+      <radio value="right"
+             data-l10n-id="right-side"/>
+      <radio value="left"
+             data-l10n-id="left-side"/>
+    </radiogroup>
+</groupbox>
+
 </html:template>

--- a/browser/components/preferences/in-content-all-new/appearance.xul
+++ b/browser/components/preferences/in-content-all-new/appearance.xul
@@ -7,34 +7,28 @@
 <script src="chrome://browser/content/preferences/in-content-all-new/appearance.js"/>
 <html:template id="template-paneAppearance">
 
-<groupbox id="preferencesGroup"
-          data-category="paneAppearance"
-          hidden="true">
-<label><html:h2 data-l10n-id="pane-windowAppearance-title"/></label>
-<label><html:h3 data-l10n-id="settings-page"/></label>
+<!-- Menu section -->
+<html:section class="setting-section"
+              data-category="paneAppearance"
+              hidden="true">
+<html:h2 data-l10n-id="pane-windowAppearance-title"/>
 
+<!-- Settings Page preferences -->
+<groupbox id="preferencesGroup"
+          class="setting-group">
+<html:h3 data-l10n-id="settings-page"/>
+
+<html:div class="group">
   <checkbox id="browser.preferences.useAllNew" data-l10n-id="display-all-new-prefs"
 							preference="browser.preferences.useAllNew"/>
-</groupbox>
-
-<!-- Window Controls Position preferences -->
-<groupbox id="windowControlsGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h3 data-l10n-id="window-controls-position-header"/></label>
-    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gAppearancePane.toggleMoveWindowControls(); moveWindowControls();">
-      <radio value="right"
-             data-l10n-id="right-side"/>
-      <radio value="left"
-             data-l10n-id="left-side"/>
-    </radiogroup>
+</html:div>
 </groupbox>
 
 <!-- Status Bar preferences -->
 <groupbox id="statusBarGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h3 data-l10n-id="statusBar-header"/></label>
+          class="setting-group">
+  <html:h3 data-l10n-id="statusBar-header"/>
+  <html:div class="group">
   <vbox id="statusBarContainer">
     <radiogroup id="statusBarRadioGroup" preference="browser.statusbar.mode" onsyncfrompreference="toggleStatusBar();">
       <radio id="showStatusBar"
@@ -51,47 +45,73 @@
                 data-l10n-id="show-btn-range"
                 onsyncfrompreference="showBtnRange();"/>
   </vbox>
+  </html:div>
+</groupbox>
+
+<!-- Window Controls Position preferences -->
+<groupbox id="windowControlsGroup"
+          class="setting-group">
+  <html:h3 data-l10n-id="window-controls-position-header"/>
+  <html:div class="group">
+    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gAppearancePane.toggleMoveWindowControls(); moveWindowControls();">
+      <radio value="right"
+             data-l10n-id="right-side"/>
+      <radio value="left"
+             data-l10n-id="left-side"/>
+    </radiogroup>
+  </html:div>
 </groupbox>
 
 <!-- Bookmarks Toolbar Position preferences -->
 <groupbox id="bookmarksBarPositionGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h3 data-l10n-id="bookmarks-bar-position-header"/></label>
+          class="setting-group">
+  <html:h3 data-l10n-id="bookmarks-bar-position-header"/>
+  <html:div class="group">
     <radiogroup id="bookmarksBarPositionRadioGroup" preference="browser.bookmarksBar.position" onsyncfrompreference="moveBookmarksBar();">
       <radio value="top"
              data-l10n-id="top-bookmarks"/>
       <radio value="bottom"
              data-l10n-id="tab-bottom"/>
     </radiogroup>
+  </html:div>
 </groupbox>
+</html:section>
+
+
+<!-- Menu section -->
+<html:section class="setting-section"
+              data-category="paneAppearance"
+              hidden="true">
+<html:h2 data-l10n-id="pane-menu-title"/>
 
 <!-- Restart Menu Item preferences -->
 <groupbox id="restartGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h2 data-l10n-id="pane-menu-title"/></label>
-  <label><html:h3 data-l10n-id="restart-header"/></label>
+          class="setting-group">
 
-  <checkbox id="browser.restart_menu.showpanelmenubtn" data-l10n-id="restart-paneluibtn"
+    <html:h3 data-l10n-id="restart-header"/>
+    <html:div class="group">
+      <checkbox id="browser.restart_menu.showpanelmenubtn" data-l10n-id="restart-paneluibtn"
 							preference="browser.restart_menu.showpanelmenubtn"/>
-  <checkbox id="browser.restart_menu.purgecache" data-l10n-id="clean-fast-restart-cache"
+      <checkbox id="browser.restart_menu.purgecache" data-l10n-id="clean-fast-restart-cache"
             preference="browser.restart_menu.purgecache"/>
-  <checkbox id="browser.restart_menu.requireconfirm" data-l10n-id="restart-reqconfirmation"
+      <checkbox id="browser.restart_menu.requireconfirm" data-l10n-id="restart-reqconfirmation"
             preference="browser.restart_menu.requireconfirm"/>
+    </html:div>
  </groupbox>
 
 <!-- Menu Icon Style preferences -->
 <groupbox id="menuIconStyleGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h3 data-l10n-id="menu-icon-style-header"/></label>
+          class="setting-group">
+  <html:h3 data-l10n-id="menu-icon-style-header"/>
+  <html:div class="group">
     <radiogroup id="menuIconStyleRadioGroup" preference="browser.menuIcon.style" onsyncfrompreference="changeMenuIconStyle();">
       <radio value="0"
              data-l10n-id="menu-icon"/>
       <radio value="1"
              data-l10n-id="browser-icon"/>
     </radiogroup>
+  </html:div>
 </groupbox>
+</html:section>
 
 </html:template>

--- a/browser/components/preferences/in-content-all-new/appearance.xul
+++ b/browser/components/preferences/in-content-all-new/appearance.xul
@@ -79,4 +79,17 @@
     </radiogroup>
 </groupbox>
 
+<!-- Bookmarks Toolbar Position preferences -->
+<groupbox id="bookmarksBarPositionGroup"
+          data-category="paneAppearance"
+          hidden="true">
+  <label><html:h2 data-l10n-id="bookmarks-bar-position-header"/></label>
+    <radiogroup id="bookmarksBarPositionRadioGroup" preference="browser.bookmarksBar.position" onsyncfrompreference="moveBookmarksBar();">
+      <radio value="top"
+             data-l10n-id="top-bookmarks"/>
+      <radio value="bottom"
+             data-l10n-id="tab-bottom"/>
+    </radiogroup>
+</groupbox>
+
 </html:template>

--- a/browser/components/preferences/in-content-all-new/appearance.xul
+++ b/browser/components/preferences/in-content-all-new/appearance.xul
@@ -10,31 +10,31 @@
 <groupbox id="preferencesGroup"
           data-category="paneAppearance"
           hidden="true">
-<label><html:h2 data-l10n-id="settings-page"/></label>
+<label><html:h2 data-l10n-id="pane-windowAppearance-title"/></label>
+<label><html:h3 data-l10n-id="settings-page"/></label>
 
   <checkbox id="browser.preferences.useAllNew" data-l10n-id="display-all-new-prefs"
 							preference="browser.preferences.useAllNew"/>
 </groupbox>
 
-<!-- Restart Menu Item preferences -->
-<groupbox id="restartGroup"
+<!-- Window Controls Position preferences -->
+<groupbox id="windowControlsGroup"
           data-category="paneAppearance"
           hidden="true">
-  <label><html:h2 data-l10n-id="restart-header"/></label>
-
-  <checkbox id="browser.restart_menu.showpanelmenubtn" data-l10n-id="restart-paneluibtn"
-							preference="browser.restart_menu.showpanelmenubtn"/>
-  <checkbox id="browser.restart_menu.purgecache" data-l10n-id="clean-fast-restart-cache"
-            preference="browser.restart_menu.purgecache"/>
-  <checkbox id="browser.restart_menu.requireconfirm" data-l10n-id="restart-reqconfirmation"
-            preference="browser.restart_menu.requireconfirm"/>
- </groupbox>
+  <label><html:h3 data-l10n-id="window-controls-position-header"/></label>
+    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gAppearancePane.toggleMoveWindowControls(); moveWindowControls();">
+      <radio value="right"
+             data-l10n-id="right-side"/>
+      <radio value="left"
+             data-l10n-id="left-side"/>
+    </radiogroup>
+</groupbox>
 
 <!-- Status Bar preferences -->
 <groupbox id="statusBarGroup"
           data-category="paneAppearance"
           hidden="true">
-  <label><html:h2 data-l10n-id="statusBar-header"/></label>
+  <label><html:h3 data-l10n-id="statusBar-header"/></label>
   <vbox id="statusBarContainer">
     <radiogroup id="statusBarRadioGroup" preference="browser.statusbar.mode" onsyncfrompreference="toggleStatusBar();">
       <radio id="showStatusBar"
@@ -53,42 +53,44 @@
   </vbox>
 </groupbox>
 
-<!-- Window Controls Position preferences -->
-<groupbox id="windowControlsGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h2 data-l10n-id="window-controls-position-header"/></label>
-    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gAppearancePane.toggleMoveWindowControls(); moveWindowControls();">
-      <radio value="right"
-             data-l10n-id="right-side"/>
-      <radio value="left"
-             data-l10n-id="left-side"/>
-    </radiogroup>
-</groupbox>
-
-<!-- Menu Icon Style preferences -->
-<groupbox id="menuIconStyleGroup"
-          data-category="paneAppearance"
-          hidden="true">
-  <label><html:h2 data-l10n-id="menu-icon-style-header"/></label>
-    <radiogroup id="menuIconStyleRadioGroup" preference="browser.menuIcon.style" onsyncfrompreference="changeMenuIconStyle();">
-      <radio value="0"
-             data-l10n-id="menu-icon"/>
-      <radio value="1"
-             data-l10n-id="browser-icon"/>
-    </radiogroup>
-</groupbox>
-
 <!-- Bookmarks Toolbar Position preferences -->
 <groupbox id="bookmarksBarPositionGroup"
           data-category="paneAppearance"
           hidden="true">
-  <label><html:h2 data-l10n-id="bookmarks-bar-position-header"/></label>
+  <label><html:h3 data-l10n-id="bookmarks-bar-position-header"/></label>
     <radiogroup id="bookmarksBarPositionRadioGroup" preference="browser.bookmarksBar.position" onsyncfrompreference="moveBookmarksBar();">
       <radio value="top"
              data-l10n-id="top-bookmarks"/>
       <radio value="bottom"
              data-l10n-id="tab-bottom"/>
+    </radiogroup>
+</groupbox>
+
+<!-- Restart Menu Item preferences -->
+<groupbox id="restartGroup"
+          data-category="paneAppearance"
+          hidden="true">
+  <label><html:h2 data-l10n-id="pane-menu-title"/></label>
+  <label><html:h3 data-l10n-id="restart-header"/></label>
+
+  <checkbox id="browser.restart_menu.showpanelmenubtn" data-l10n-id="restart-paneluibtn"
+							preference="browser.restart_menu.showpanelmenubtn"/>
+  <checkbox id="browser.restart_menu.purgecache" data-l10n-id="clean-fast-restart-cache"
+            preference="browser.restart_menu.purgecache"/>
+  <checkbox id="browser.restart_menu.requireconfirm" data-l10n-id="restart-reqconfirmation"
+            preference="browser.restart_menu.requireconfirm"/>
+ </groupbox>
+
+<!-- Menu Icon Style preferences -->
+<groupbox id="menuIconStyleGroup"
+          data-category="paneAppearance"
+          hidden="true">
+  <label><html:h3 data-l10n-id="menu-icon-style-header"/></label>
+    <radiogroup id="menuIconStyleRadioGroup" preference="browser.menuIcon.style" onsyncfrompreference="changeMenuIconStyle();">
+      <radio value="0"
+             data-l10n-id="menu-icon"/>
+      <radio value="1"
+             data-l10n-id="browser-icon"/>
     </radiogroup>
 </groupbox>
 

--- a/browser/components/preferences/in-content-all-new/downloads.xul
+++ b/browser/components/preferences/in-content-all-new/downloads.xul
@@ -11,10 +11,12 @@
 <script src="chrome://browser/content/preferences/in-content-all-new/downloads.js"/>
 
 <html:template id="template-paneDownloads">
-
+<html:section class="setting-section"
+              data-category="paneDownloads"
+              hidden="true">
 <!--Downloads-->
-<groupbox id="downloadsGroup" data-category="paneDownloads" hidden="true">
-  <label><html:h2 data-l10n-id="download-header"/></label>
+<html:h2 data-l10n-id="download-header"/>
+<groupbox id="downloadsGroup" class="setting-group">
 
   <radiogroup id="saveWhere"
               preference="browser.download.useDownloadDir"
@@ -23,9 +25,12 @@
       <radio id="saveTo"
              value="true"
              data-l10n-id="download-save-to"/>
-      <textbox id="downloadFolder" flex="1"
+      <html:input id="downloadFolder" type="text"
                readonly="true"
                aria-labelledby="saveTo"/>
+      <!-- <textbox id="downloadFolder" flex="1"
+               readonly="true"
+               aria-labelledby="saveTo"/> -->
       <button id="chooseFolder"
               is="highlightable-button"
               class="accessory-button"
@@ -41,15 +46,20 @@
   </radiogroup>
 </groupbox>
 
+</html:section>
 
 #ifdef HAVE_SHELL_SERVICE
   <stringbundle id="bundleShell" src="chrome://browser/locale/shellservice.properties"/>
   <stringbundle id="bundleBrand" src="chrome://branding/locale/brand.properties"/>
 #endif
 
+<html:section class="setting-section"
+              data-category="paneDownloads"
+              hidden="true">
 <!-- Update -->
-<groupbox id="updateApp" data-category="paneDownloads" hidden="true">
-  <label><html:h2 data-l10n-id="update-application-title"/></label>
+<html:h2 data-l10n-id="update-application-title"/>
+
+<groupbox id="updateApp" class="setting-section">
 
   <label class="search-header" hidden="true"><html:h2 data-l10n-id="update-application-title"/></label>
 
@@ -204,5 +214,7 @@
             data-l10n-id="update-enable-search-update"
             preference="browser.search.update"/>
 </groupbox>
+
+</html:section>
 
 </html:template>

--- a/browser/components/preferences/in-content-all-new/main.xul
+++ b/browser/components/preferences/in-content-all-new/main.xul
@@ -10,13 +10,35 @@
 <stringbundle id="bundlePreferences" src="chrome://browser/locale/preferences.properties"/>
 
 <html:template id="template-paneGeneral">
-
+<html:section class="setting-section"
+              data-category="paneGeneral"
+              hidden="true">
 <!-- Startup -->
-<groupbox id="startupGroup"
-          data-category="paneGeneral"
-          hidden="true">
-  <label><html:h2 class="subcategory-header" data-l10n-id="startup-header"/></label>
-
+<html:h2 data-l10n-id="startup-header"/>
+#ifdef HAVE_SHELL_SERVICE
+<groupbox id="defaultBrowserGroup" class="setting-group">
+  <vbox id="defaultBrowserBox">
+    <deck id="setDefaultPane">
+      <hbox align="center">
+        <image class="face-sad"/>
+        <label id="isNotDefaultLabel" flex="1" data-l10n-id="is-not-default"/>
+      </hbox>
+      <hbox align="center">
+        <image class="face-smile"/>
+        <label id="isDefaultLabel" flex="1" data-l10n-id="is-default"/>
+      </hbox>
+    </deck>
+    <button id="setDefaultButton"
+                is="highlightable-button"
+                class="accessory-button"
+                data-l10n-id="set-as-my-default-browser"
+                preference="pref.general.disable_button.default_browser"/>
+      <checkbox id="alwaysCheckDefault" preference="browser.shell.checkDefaultBrowser"
+              data-l10n-id="always-check-default"/>
+  </vbox>
+</groupbox>
+#endif
+<groupbox id="sessionGroup" class="setting-group">
   <vbox id="startupPageBox">
     <checkbox id="browserRestoreSession"
               data-l10n-id="startup-restore-previous-session"/>
@@ -27,33 +49,15 @@
                 data-l10n-id="startup-restore-warn-on-quit"/>
     </hbox>
   </vbox>
-
-#ifdef HAVE_SHELL_SERVICE
-  <vbox id="defaultBrowserBox">
-    <checkbox id="alwaysCheckDefault" preference="browser.shell.checkDefaultBrowser"
-              data-l10n-id="always-check-default"/>
-    <deck id="setDefaultPane">
-      <hbox align="center" class="indent">
-        <image class="face-sad"/>
-        <label id="isNotDefaultLabel" flex="1" data-l10n-id="is-not-default"/>
-        <button id="setDefaultButton"
-                is="highlightable-button"
-                class="accessory-button"
-                data-l10n-id="set-as-my-default-browser"
-                preference="pref.general.disable_button.default_browser"/>
-      </hbox>
-      <hbox align="center" class="indent">
-        <image class="face-smile"/>
-        <label id="isDefaultLabel" flex="1" data-l10n-id="is-default"/>
-      </hbox>
-    </deck>
-  </vbox>
-#endif
 </groupbox>
+</html:section>
 
+<html:section class="setting-section"
+              data-category="paneGeneral"
+              hidden="true">
 <!-- Languages -->
-<groupbox id="languagesGroup" data-category="paneGeneral" hidden="true">
-  <label><html:h2 data-l10n-id="language-header"/></label>
+<html:h2 data-l10n-id="language-header"/>
+<groupbox id="languagesGroup">
 
   <vbox id="browserLanguagesBox" align="start" hidden="true">
     <description flex="1" controls="chooseBrowserLanguage" data-l10n-id="choose-browser-language-description"/>
@@ -118,12 +122,15 @@
           onsynctopreference="return gMainPane.writeCheckSpelling();"
           preference="layout.spellcheckDefault"/>
 </groupbox>
+</html:section>
 
+<html:section class="setting-section"
+              data-category="paneGeneral"
+              hidden="true">
 <!-- Network Settings-->
-<groupbox id="connectionGroup" data-category="paneGeneral" hidden="true">
   <label class="search-header" hidden="true"><html:h2 data-l10n-id="network-settings-title"/></label>
-  <label><html:h2 data-l10n-id="network-settings-title"/></label>
-
+  <html:h2 data-l10n-id="network-settings-title"/>
+<groupbox id="connectionGroup">
   <hbox align="center">
     <hbox align="center" flex="1">
       <description id="connectionSettingsDescription" control="connectionSettings"/>
@@ -168,5 +175,6 @@
     </hbox>
   </hbox>
 </groupbox>
+</html:section>
 
 </html:template>

--- a/browser/components/preferences/in-content-all-new/preferences.xul
+++ b/browser/components/preferences/in-content-all-new/preferences.xul
@@ -8,7 +8,6 @@
 <?xml-stylesheet href="chrome://browser/skin/preferences/preferences.css"?>
 <?xml-stylesheet href="chrome://global/skin/in-content/common.css"?>
 <?xml-stylesheet href="chrome://browser/skin/preferences/in-content/preferences.css"?>
-<?xml-stylesheet href="chrome://browser/skin/preferences/in-content-all-new/preferences.css"?>
 <?xml-stylesheet href="chrome://browser/content/preferences/handlers.css"?>
 <?xml-stylesheet href="chrome://browser/skin/preferences/applications.css"?>
 <?xml-stylesheet href="chrome://browser/skin/preferences/in-content/search.css"?>

--- a/browser/components/preferences/in-content-all-new/privacy.xul
+++ b/browser/components/preferences/in-content-all-new/privacy.xul
@@ -348,6 +348,45 @@
       </radiogroup>
 </groupbox>
 
+<!-- WebRTC peer connection -->
+<groupbox id="webrtc">
+  <html:h3 data-l10n-id="webrtc-header"/>
+  <hbox align="center">
+    <checkbox id="media.peerconnection.enabled"
+              class="tail-with-learn-more"
+              data-l10n-id="webrtcp2preference"
+              preference="media.peerconnection.enabled"/>
+    <label class="learnMore" is="text-link" href="https://bugzilla.mozilla.org/show_bug.cgi?id=959893"
+           data-l10n-id="content-blocking-learn-more"/>
+  </hbox>
+</groupbox>
+
+<!-- HTTP Referrer Header-->
+<groupbox id="refheader">
+    <html:h3 data-l10n-id="ref-header"/>
+    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
+
+    <hbox align="center">
+    <hbox>
+      <label id="historyModeLabel"
+             control="doNotsendSecureXSiteReferrer"
+             data-l10n-id="history-remember-label"/>
+    </hbox>
+    <hbox>
+      <menulist id="doNotsendSecureXSiteReferrer" preference="network.http.sendRefererHeader">
+        <menupopup>
+          <menuitem data-l10n-id="sendRefererHeaderopt0"
+                    value="0"/>
+          <menuitem data-l10n-id="sendRefererHeaderopt1"
+                    value="1"/>
+          <menuitem data-l10n-id="sendRefererHeaderopt2"
+                    value="2"/>
+        </menupopup>
+      </menulist>
+    </hbox>
+    </hbox>
+</groupbox>
+
 <!-- Site Data -->
 <groupbox id="siteDataGroup" aria-describedby="totalSiteDataSize">
   <html:h3 data-l10n-id="sitedata-header"/>
@@ -834,34 +873,6 @@
               "
               oncommand="gPrivacyPane.showScriptExceptions();"/>
     </vbox>
-  </hbox>
-
-  <hbox align="center">
-    <checkbox id="media.peerconnection.enabled"
-              class="tail-with-learn-more"
-              data-l10n-id="webrtcp2preference"
-              preference="media.peerconnection.enabled"/>
-    <label class="learnMore" is="text-link" href="https://bugzilla.mozilla.org/show_bug.cgi?id=959893"
-           data-l10n-id="content-blocking-learn-more"/>
-  </hbox>
-
-  <hbox align="center">
-    <label id="historyModeLabel"
-           control="doNotsendSecureXSiteReferrer"
-           data-l10n-id="history-remember-label"/>
-    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
-    <hbox>
-      <menulist id="doNotsendSecureXSiteReferrer" preference="network.http.sendRefererHeader">
-        <menupopup>
-          <menuitem data-l10n-id="sendRefererHeaderopt0"
-                    value="0"/>
-          <menuitem data-l10n-id="sendRefererHeaderopt1"
-                    value="1"/>
-          <menuitem data-l10n-id="sendRefererHeaderopt2"
-                    value="2"/>
-        </menupopup>
-      </menulist>
-    </hbox>
   </hbox>
 
 </groupbox>

--- a/browser/components/preferences/in-content-all-new/privacy.xul
+++ b/browser/components/preferences/in-content-all-new/privacy.xul
@@ -8,11 +8,13 @@
 <stringbundle id="bundlePreferences" src="chrome://browser/locale/preferences/preferences.properties"/>
 <stringbundle id="signonBundle" src="chrome://passwordmgr/locale/passwordmgr.properties"/>
 <html:template id="template-panePrivacy">
-
+<html:section class="setting-section"
+              data-category="panePrivacy"
+              hidden="true">
+  <html:h2 data-l10n-id="privacy-header"/>
 <!-- Tracking / Content Blocking -->
-<groupbox id="trackingGroup" data-category="panePrivacy" hidden="true" aria-describedby="contentBlockingDescription">
-  <label><html:h2 data-l10n-id="privacy-header"/></label>
-  <label id="contentBlockingHeader"><html:h3 data-l10n-id="content-blocking-header"/></label>
+<groupbox id="trackingGroup" aria-describedby="contentBlockingDescription">
+  <html:h3 data-l10n-id="content-blocking-header"/>
   <vbox data-subcategory="trackingprotection">
     <hbox align="start">
       <image id="trackingProtectionShield"/>
@@ -331,7 +333,12 @@
         </vbox>
       </radiogroup>
     </vbox>
-    <vbox id="doNotTrackLearnMoreBox">
+  </vbox>
+</groupbox>
+
+<!-- Do Not Track signal -->
+<groupbox id="dnt">
+  <html:h3 data-l10n-id="dnt-header"/>
       <label><label class="tail-with-learn-more" data-l10n-id="do-not-track-description" id="doNotTrackDesc"></label><label
       class="learnMore" is="text-link" href="https://www.mozilla.org/dnt"
       data-l10n-id="do-not-track-learn-more"></label></label>
@@ -339,45 +346,30 @@
         <radio value="true" data-l10n-id="do-not-track-option-always"/>
         <radio value="false" data-l10n-id="do-not-track-option-default-content-blocking-known"/>
       </radiogroup>
-    </vbox>
-  </vbox>
 </groupbox>
 
 <!-- Site Data -->
-<groupbox id="siteDataGroup" data-category="panePrivacy" hidden="true" aria-describedby="totalSiteDataSize">
-  <label><html:h3 data-l10n-id="sitedata-header"/></label>
+<groupbox id="siteDataGroup" aria-describedby="totalSiteDataSize">
+  <html:h3 data-l10n-id="sitedata-header"/>
 
-  <hbox data-subcategory="sitedata" align="baseline">
-    <vbox flex="1">
       <description class="description-with-side-element" flex="1">
         <html:span id="totalSiteDataSize" class="tail-with-learn-more"></html:span>
         <label id="siteDataLearnMoreLink"
           class="learnMore" is="text-link" data-l10n-id="sitedata-learn-more"/>
       </description>
+
+      <html:div class="group">
       <hbox flex="1" id="deleteOnCloseNote" class="info-panel">
         <description flex="1" data-l10n-id="sitedata-delete-on-close-private-browsing" />
       </hbox>
-      <hbox id="keepRow"
-            align="center">
-        <checkbox id="deleteOnClose"
-                  data-l10n-id="sitedata-delete-on-close"
-                  preference="network.cookie.lifetimePolicy"
-                  onsyncfrompreference="return gPrivacyPane.readDeleteOnClose();"
-                  onsynctopreference="return gPrivacyPane.writeDeleteOnClose();"
-                  flex="1" />
-      </hbox>
-    </vbox>
-    <vbox align="end">
+    <hbox id="cookiesButtons">
       <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
-      <hbox>
         <button id="clearSiteDataButton"
             is="highlightable-button"
             class="accessory-button"
             icon="clear"
             search-l10n-ids="clear-site-data-cookies-empty.label, clear-site-data-cache-empty.label"
             data-l10n-id="sitedata-clear"/>
-      </hbox>
-      <hbox>
         <button id="siteDataSettings"
                 is="highlightable-button"
                 class="accessory-button"
@@ -390,8 +382,6 @@
                   site-data-settings-description,
                   site-data-remove-all.label,
                 "/>
-      </hbox>
-      <hbox>
         <button id="cookieExceptions"
                 is="highlightable-button"
                 class="accessory-button"
@@ -407,22 +397,29 @@
                   permissions-button-ok.label,
                   permissions-exceptions-cookie-desc,
                 " />
-      </hbox>
-    </vbox>
-  </hbox>
+    </hbox>
+    </html:div>
+    <html:div>
+                <checkbox id="deleteOnClose"
+                  data-l10n-id="sitedata-delete-on-close"
+                  preference="network.cookie.lifetimePolicy"
+                  onsyncfrompreference="return gPrivacyPane.readDeleteOnClose();"
+                  onsynctopreference="return gPrivacyPane.writeDeleteOnClose();"
+                  flex="1" />
+    </html:div>
 </groupbox>
 
 <!-- Passwords -->
-<groupbox id="passwordsGroup" orient="vertical" data-category="panePrivacy" hidden="true">
-  <label><html:h3 data-l10n-id="logins-header"/></label>
-
-  <vbox id="passwordSettings">
-    <hbox id="savePasswordsBox">
-      <checkbox id="savePasswords"
+<groupbox id="passwordsGroup" >
+  <html:h3 data-l10n-id="logins-header"/>
+  <html:div>
+        <checkbox id="savePasswords"
                 data-l10n-id="forms-ask-to-save-logins"
                 preference="signon.rememberSignons"
                 onsyncfrompreference="return gPrivacyPane.readSavePasswords();"
                 flex="1" />
+  </html:div>
+    <html:div>
       <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
       <hbox>
         <button id="passwordExceptions"
@@ -436,8 +433,6 @@
                   permissions-exceptions-saved-logins-desc,
                 "/>
       </hbox>
-    </hbox>
-    <hbox id="showPasswordBox" pack="end">
       <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
       <hbox>
         <button id="showPasswords"
@@ -447,12 +442,13 @@
                 search-l10n-ids="forms-saved-logins.label"
                 preference="pref.privacy.disable_button.view_passwords"/>
       </hbox>
-    </hbox>
-  </vbox>
-  <hbox id="masterPasswordRow">
+    </html:div>
+  <html:div>
     <checkbox id="useMasterPassword"
               data-l10n-id="forms-master-pw-use"
               flex="1"/>
+  </html:div>
+  <html:div>
     <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
     <hbox>
       <button id="changeMasterPassword"
@@ -460,18 +456,18 @@
               class="accessory-button"
               data-l10n-id="forms-master-pw-change"/>
     </hbox>
-  </hbox>
+  </html:div>
 </groupbox>
 
 <!-- The form autofill section is inserted in to this box
      after the form autofill extension has initialized. -->
 <groupbox id="formAutofillGroupBox"
-          data-category="panePrivacy"
-          data-subcategory="form-autofill" hidden="true"></groupbox>
+          data-subcategory="form-autofill"></groupbox>
 
 <!-- History -->
-<groupbox id="historyGroup" data-category="panePrivacy" hidden="true">
-  <label><html:h3 data-l10n-id="history-header"/></label>
+<groupbox id="historyGroup">
+  <html:h3 data-l10n-id="history-header"/>
+  <html:div class="group">
   <hbox align="center">
     <label id="historyModeLabel"
            control="historyMode"
@@ -498,7 +494,8 @@
       </menulist>
     </hbox>
   </hbox>
-  <hbox>
+  </html:div>
+  <html:div>
     <deck id="historyPane" flex="1">
       <vbox id="historyRememberPane">
         <hbox align="center" flex="1">
@@ -544,12 +541,16 @@
         </vbox>
       </vbox>
     </deck>
-    <vbox id="historyButtons" align="end">
-      <button id="clearHistoryButton"
-              is="highlightable-button"
-              class="accessory-button"
-              icon="clear"
-              data-l10n-id="history-clear-button"/>
+    </html:div>
+    <html:div>
+    <hbox id="historyButtons" align="end">
+      <hbox>
+        <button id="clearHistoryButton"
+                is="highlightable-button"
+                class="accessory-button"
+                icon="clear"
+                data-l10n-id="history-clear-button"/>
+      </hbox>
       <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
       <hbox>
         <button id="clearDataSettings"
@@ -569,15 +570,13 @@
                   item-offline-apps.label
                 "/>
       </hbox>
-    </vbox>
-  </hbox>
+    </hbox>
+  </html:div>
 </groupbox>
 
 <!-- Address Bar -->
-<groupbox id="locationBarGroup"
-          data-category="panePrivacy"
-          hidden="true">
-  <label><html:h3 data-l10n-id="addressbar-header"/></label>
+<groupbox id="locationBarGroup">
+  <html:h3 data-l10n-id="addressbar-header"/>
   <label id="locationBarSuggestionLabel" data-l10n-id="addressbar-suggest"/>
   <checkbox id="historySuggestion" data-l10n-id="addressbar-locbar-history-option"
             preference="browser.urlbar.suggest.history"/>
@@ -585,15 +584,18 @@
             preference="browser.urlbar.suggest.bookmark"/>
   <checkbox id="openpageSuggestion" data-l10n-id="addressbar-locbar-openpage-option"
             preference="browser.urlbar.suggest.openpage"/>
-  <label id="openSearchEnginePreferences" is="text-link"
+    <label id="openSearchEnginePreferences" is="text-link"
          data-l10n-id="addressbar-suggestions-settings"/>
 </groupbox>
-
+</html:section>
 
 <!-- Permissions -->
-<groupbox id="permissionsGroup" data-category="panePrivacy" hidden="true" data-subcategory="permissions">
-  <label><html:h2 data-l10n-id="permissions-header"/></label>
-  <label class="search-header" hidden="true"><html:h2 data-l10n-id="permissions-header"/></label>
+<html:section class="setting-section"
+              data-category="panePrivacy"
+              hidden="true">
+<html:h2 data-l10n-id="permissions-header"/>
+<label class="search-header" hidden="true"><html:h2 data-l10n-id="permissions-header"/></label>
+<groupbox id="permissionsGroup">
 
   <!-- The hbox around the buttons is to compute the search tooltip position properly -->
   <vbox>
@@ -932,32 +934,33 @@
   </vbox>
 </groupbox>
 #endif
+</html:section>
 
-
+<html:section class="setting-section"
+              data-category="panePrivacy"
+              hidden="true">
+<html:h2 data-l10n-id="security-header"/>
 <!-- addons, forgery (phishing) UI Security -->
-<groupbox id="browsingProtectionGroup" data-category="panePrivacy" hidden="true">
-  <label><html:h2 data-l10n-id="security-header"/></label>
-  <label><html:h3 data-l10n-id="security-browsing-protection"/></label>
-  <hbox align = "center">
+<groupbox id="browsingProtectionGroup" class="setting-group">
+  <html:h3 data-l10n-id="security-browsing-protection"/>
+  <html:div class="group">
     <checkbox id="enableSafeBrowsing"
-              data-l10n-id="security-enable-safe-browsing"
-              class="tail-with-learn-more"/>
+              data-l10n-id="security-enable-safe-browsing"/>
     <label id="enableSafeBrowsingLearnMore"
-           class="learnMore" is="text-link" data-l10n-id="security-enable-safe-browsing-link"/>
-  </hbox>
-  <vbox class="indent">
+           class="learnMore indent tip-caption text-link" is="text-link" data-l10n-id="security-enable-safe-browsing-link"/>
     <checkbox id="blockDownloads"
               data-l10n-id="security-block-downloads"/>
     <checkbox id="blockUncommonUnwanted"
               data-l10n-id="security-block-uncommon-software"/>
-  </vbox>
+  </html:div>
 </groupbox>
 
 <!-- Certificates -->
-<groupbox id="certSelection" data-category="panePrivacy" hidden="true">
-  <label><html:h3 data-l10n-id="certs-header"/></label>
+<groupbox id="certSelection" class="setting-group">
+  <html:h3 data-l10n-id="certs-header"/>
   <description id="CertSelectionDesc" control="certSelection" data-l10n-id="certs-personal-label"/>
 
+  <html:div class="group">
   <!--
     The values on these radio buttons may look like l10n issues, but
     they're not - this preference uses *those strings* as its values.
@@ -972,15 +975,14 @@
     <radio data-l10n-id="certs-select-ask-option"
            value="Ask Every Time"/>
   </radiogroup>
-  <hbox align="start">
     <checkbox id="enableOCSP"
               data-l10n-id="certs-enable-ocsp"
               onsyncfrompreference="return gPrivacyPane.readEnableOCSP();"
               onsynctopreference="return gPrivacyPane.writeEnableOCSP();"
               preference="security.OCSP.enabled"
               flex="1" />
-    <vbox>
       <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
+      <hbox>
       <hbox pack="end">
         <button id="viewCertificatesButton"
                 is="highlightable-button"
@@ -1022,7 +1024,8 @@
                   devmgr-button-unload.label
                 "/>
       </hbox>
-    </vbox>
-  </hbox>
+      </hbox>
+      </html:div>
 </groupbox>
+</html:section>
 </html:template>

--- a/browser/components/preferences/in-content-all-new/search.xul
+++ b/browser/components/preferences/in-content-all-new/search.xul
@@ -1,52 +1,57 @@
     <script src="chrome://browser/content/preferences/in-content/search.js"/>
     <html:template id="template-paneSearch">
 
-    <groupbox id="searchbarGroup" data-category="paneSearch" hidden="true">
-      <label><html:h2 data-l10n-id="pane-search-title"/></label>
-      <label control="searchBarVisibleGroup"><html:h3 data-l10n-id="search-bar-header"/></label>
-      <radiogroup id="searchBarVisibleGroup" preference="browser.search.widget.inNavBar">
-        <radio id="searchBarHiddenRadio" value="false" data-l10n-id="search-bar-hidden"/>
-        <image class="searchBarImage searchBarHiddenImage" role="presentation"/>
-        <radio id="searchBarShownRadio" value="true" data-l10n-id="search-bar-shown"/>
-        <image class="searchBarImage searchBarShownImage" role="presentation"/>
-      </radiogroup>
+    <html:section class="setting-section"
+              data-category="paneSearch"
+              hidden="true">
+    <html:h2 data-l10n-id="pane-search-title"/>
+
+    <groupbox id="searchbarGroup">
+      <html:h3 data-l10n-id="search-bar-header"/>
+      <html:div class="group">
+        <radiogroup id="searchBarVisibleGroup" preference="browser.search.widget.inNavBar">
+          <radio id="searchBarHiddenRadio" value="false" data-l10n-id="search-bar-hidden"/>
+          <image class="searchBarImage searchBarHiddenImage" role="presentation"/>
+          <radio id="searchBarShownRadio" value="true" data-l10n-id="search-bar-shown"/>
+          <image class="searchBarImage searchBarShownImage" role="presentation"/>
+        </radiogroup>
+      </html:div>
     </groupbox>
 
     <!-- Default Search Engine -->
-    <groupbox id="defaultEngineGroup" data-category="paneSearch" hidden="true">
-      <label><html:h3 data-l10n-id="search-engine-default-header" /></label>
-      <description data-l10n-id="search-engine-default-desc" />
+    <groupbox id="defaultEngineGroup" class="setting-group">
+      <html:h3 data-l10n-id="search-engine-default-header" />
 
-      <hbox id="browserDefaultSearchExtensionContent"
-            align="center" hidden="true" class="extension-controlled">
-        <description control="disableDefaultSearchExtension" flex="1"/>
-      </hbox>
+        <description data-l10n-id="search-engine-default-desc" />
 
-      <hbox>
-        <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
-        <hbox>
-          <menulist id="defaultEngine">
-            <menupopup/>
-          </menulist>
+        <hbox id="browserDefaultSearchExtensionContent"
+              align="center" hidden="true" class="extension-controlled">
+          <description control="disableDefaultSearchExtension" flex="1"/>
         </hbox>
-      </hbox>
-
-      <checkbox id="suggestionsInSearchFieldsCheckbox"
-                data-l10n-id="search-suggestions-option"
-                preference="browser.search.suggest.enabled"/>
-      <vbox class="indent">
-        <checkbox id="urlBarSuggestion" data-l10n-id="search-show-suggestions-url-bar-option" />
-        <checkbox id="showSearchSuggestionsFirstCheckbox"
-                  data-l10n-id="search-show-suggestions-above-history-option"/>
-        <hbox id="urlBarSuggestionPermanentPBLabel"
-              align="center" class="indent">
-          <label flex="1" data-l10n-id="search-suggestions-cant-show" />
-        </hbox>
-      </vbox>
+            <menulist id="defaultEngine">
+              <menupopup/>
+            </menulist>
     </groupbox>
 
-    <groupbox id="oneClickSearchProvidersGroup" data-category="paneSearch" hidden="true">
-      <label><html:h3 data-l10n-id="search-one-click-header" /></label>
+    <groupbox id="searchSuggestionsGroup" class="setting-group">
+      <html:h3 data-l10n-id="search-suggestions-header" />
+        <checkbox id="suggestionsInSearchFieldsCheckbox"
+                  data-l10n-id="search-suggestions-option"
+                  preference="browser.search.suggest.enabled"/>
+        <vbox class="indent">
+          <checkbox id="urlBarSuggestion" data-l10n-id="search-show-suggestions-url-bar-option" />
+          <checkbox id="showSearchSuggestionsFirstCheckbox"
+                    data-l10n-id="search-show-suggestions-above-history-option"/>
+          <hbox id="urlBarSuggestionPermanentPBLabel"
+                align="center" class="indent">
+            <label flex="1" data-l10n-id="search-suggestions-cant-show" />
+          </hbox>
+        </vbox>
+    </groupbox>
+
+    <groupbox id="oneClickSearchProvidersGroup">
+      <html:h3 data-l10n-id="search-one-click-header" />
+
       <description data-l10n-id="search-one-click-desc" />
 
       <tree id="engineList" flex="1" rows="8" hidecolumnpicker="true" editable="true"
@@ -77,4 +82,5 @@
         <label id="addEngines" data-l10n-id="search-find-more-link" is="text-link"></label>
       </hbox>
     </groupbox>
+    </html:section>
     </html:template>

--- a/browser/components/preferences/in-content-all-new/sync.xul
+++ b/browser/components/preferences/in-content-all-new/sync.xul
@@ -6,8 +6,8 @@
 
 <script src="chrome://browser/content/preferences/in-content/sync.js"/>
 <html:template id="template-paneSync">
-
-<deck id="weavePrefsDeck" data-category="paneSync" hidden="true"
+<html:section xmlns:html="http://www.w3.org/1999/xhtml" class="setting-section" data-category="paneSync" hidden="true">
+<deck id="weavePrefsDeck"
       data-hidden-from-search="true">
   <groupbox id="noFxaAccount">
   <label><html:h2 data-l10n-id="pane-sync-title2"/></label>
@@ -203,4 +203,5 @@
     </vbox>
   </vbox>
 </deck>
+</html:section>
 </html:template>

--- a/browser/components/preferences/in-content-all-new/tabs.xul
+++ b/browser/components/preferences/in-content-all-new/tabs.xul
@@ -8,9 +8,11 @@
 <html:template id="template-paneTabs">
 
 <!-- Tab preferences -->
-<groupbox data-category="paneTabs"
-          hidden="true">
-    <label><html:h2 data-l10n-id="tabs-group-header"/></label>
+<html:section class="setting-section"
+              data-category="paneTabs"
+              hidden="true">
+<html:h2 data-l10n-id="tabs-group-header"/>
+<groupbox>
 
     <checkbox id="ctrlTabRecentlyUsedOrder" data-l10n-id="ctrl-tab-recently-used-order"
               preference="browser.ctrlTab.recentlyUsedOrder"
@@ -99,5 +101,5 @@
     </vbox>
 
 </groupbox>
-
+</html:section>
 </html:template>

--- a/browser/components/preferences/in-content-all-new/webpages.xul
+++ b/browser/components/preferences/in-content-all-new/webpages.xul
@@ -8,26 +8,28 @@
 <script src="chrome://browser/content/preferences/in-content-all-new/webpages.js"/>
 <html:template id="template-paneWebpages">
 
-<!-- Performance -->
-<groupbox id="performanceGroup" data-category="paneWebpages" hidden="true">
-  <label class="search-header" hidden="true"><html:h2 data-l10n-id="performance-title"/></label>
-  <label><html:h2 data-l10n-id="pane-webpages-title"/></label>
-  <label><html:h3 data-l10n-id="performance-title"/></label>
 
-  <hbox align="center">
+<html:section class="setting-section"
+              data-category="paneWebpages"
+              hidden="true">
+<html:h2 data-l10n-id="pane-webpages-title"/>
+
+<!-- Performance -->
+<groupbox id="performanceGroup" class="setting-group">
+  <label class="search-header" hidden="true"><html:h3 data-l10n-id="performance-title"/></label>
+  <html:h3 data-l10n-id="performance-title"/>
+
+  <html:div class="group">
     <checkbox id="useRecommendedPerformanceSettings"
-              class="tail-with-learn-more"
               data-l10n-id="performance-use-recommended-settings-checkbox"
               preference="browser.preferences.defaultPerformanceSettings.enabled"/>
-    <label id="performanceSettingsLearnMore" class="learnMore" data-l10n-id="performance-settings-learn-more" is="text-link"/>
-  </hbox>
   <description class="indent tip-caption" data-l10n-id="performance-use-recommended-settings-desc"/>
+  <label id="performanceSettingsLearnMore" class="learnMore indent tip-caption" data-l10n-id="performance-settings-learn-more" is="text-link"/>
 
-  <vbox id="performanceSettings" class="indent" hidden="true">
+  <vbox id="performanceSettings" hidden="true">
     <checkbox id="allowHWAccel"
               data-l10n-id="performance-allow-hw-accel"
               preference="layers.acceleration.disabled"/>
-    <hbox align="center">
       <label id="limitContentProcess" data-l10n-id="performance-limit-content-process-option" control="contentProcessCount"/>
       <menulist id="contentProcessCount" preference="dom.ipc.processCount">
         <menupopup>
@@ -41,26 +43,25 @@
           <menuitem label="8" value="8"/>
         </menupopup>
       </menulist>
-    </hbox>
     <description id="contentProcessCountEnabledDescription" class="tip-caption" data-l10n-id="performance-limit-content-process-enabled-desc"/>
     <description id="contentProcessCountDisabledDescription" class="tip-caption" data-l10n-id="performance-limit-content-process-blocked-desc">
       <html:a class="text-link" data-l10n-name="learn-more" href="https://wiki.mozilla.org/Electrolysis"/>
     </description>
   </vbox>
+  </html:div>
 </groupbox>
 
 <!-- Browsing -->
-<groupbox id="browsingGroup" data-category="paneWebpages" hidden="true">
+<groupbox id="browsingGroup" class="setting-group">
   <label class="search-header" hidden="true"><html:h2 data-l10n-id="browsing-title"/></label>
-  <label><html:h3 data-l10n-id="browsing-title"/></label>
-
+  <html:h3 data-l10n-id="browsing-title"/>
+<html:div class="group">
   <checkbox id="useAutoScroll"
             data-l10n-id="browsing-use-autoscroll"
             preference="general.autoScroll"/>
   <checkbox id="useSmoothScrolling"
             data-l10n-id="browsing-use-smooth-scrolling"
             preference="general.smoothScroll"/>
-
 #ifdef XP_WIN
   <checkbox id="useOnScreenKeyboard"
             hidden="true"
@@ -73,11 +74,27 @@
   <checkbox id="searchStartTyping"
             data-l10n-id="browsing-search-on-start-typing"
             preference="accessibility.typeaheadfind"/>
+</html:div>
 </groupbox>
 
+<!-- DRM Content -->
+<groupbox id="drmGroup" class="setting-group" data-category="paneWebpages" data-subcategory="drm">
+  <html:h3 data-l10n-id="drm-content-header"/>
+  <hbox align="center">
+    <checkbox id="playDRMContent" preference="media.eme.enabled"
+              class="tail-with-learn-more" data-l10n-id="play-drm-content" />
+    <label id="playDRMContentLink" class="learnMore" data-l10n-id="play-drm-content-learn-more" is="text-link"/>
+  </hbox>
+</groupbox>
+
+</html:section>
+
 <!-- Applications -->
-<groupbox id="applicationsGroup" data-category="paneWebpages" hidden="true">
-  <label><html:h2 data-l10n-id="applications-header"/></label>
+<html:section class="setting-section"
+              data-category="paneWebpages"
+              hidden="true">
+<html:h2 data-l10n-id="applications-header"/>
+<groupbox id="applicationsGroup">
   <description data-l10n-id="applications-description"/>
   <textbox id="filter" flex="1"
            is="search-textbox"
@@ -95,21 +112,15 @@
   <richlistbox id="handlersView"
                preference="pref.downloads.disable_button.edit_actions"/>
 </groupbox>
+</html:section>
 
-
-<!-- DRM Content -->
-<groupbox id="drmGroup" data-category="paneWebpages" data-subcategory="drm" hidden="true">
-  <label><html:h2 data-l10n-id="drm-content-header"/></label>
-  <hbox align="center">
-    <checkbox id="playDRMContent" preference="media.eme.enabled"
-              class="tail-with-learn-more" data-l10n-id="play-drm-content" />
-    <label id="playDRMContentLink" class="learnMore" data-l10n-id="play-drm-content-learn-more" is="text-link"/>
-  </hbox>
-</groupbox>
+<html:section class="setting-section"
+              data-category="paneWebpages"
+              hidden="true">
 
 <!-- Fonts and Colors -->
-<groupbox id="fontsGroup" data-category="paneWebpages" hidden="true">
-  <label><html:h2 data-l10n-id="fonts-and-colors-header"/></label>
+<html:h2 data-l10n-id="fonts-and-colors-header"/>
+<groupbox id="fontsGroup">
 
   <hbox id="fontSettings">
     <hbox align="center" flex="1">
@@ -222,33 +233,28 @@
                 fonts-languages-fallback-name-vietnamese.label,
                 fonts-languages-fallback-name-other.label,
               " />
-    </hbox>
-  </hbox>
-  <hbox id="colorsSettings">
-    <spacer flex="1" />
-    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
-    <hbox>
-      <button id="colors"
-              is="highlightable-button"
-              class="accessory-button"
-              icon="select-color"
-              data-l10n-id="colors-settings"
-              search-l10n-ids="
-                colors-page-override,
-                colors-page-override-option-always.label,
-                colors-page-override-option-auto.label,
-                colors-page-override-option-never.label,
-                colors-text-and-background,
-                colors-text-header,
-                colors-background,
-                colors-use-system,
-                colors-underline-links,
-                colors-links-header,
-                colors-unvisited-links,
-                colors-visited-links
-              "/>
+              <button id="colors"
+                      is="highlightable-button"
+                      class="accessory-button"
+                      icon="select-color"
+                      data-l10n-id="colors-settings"
+                      search-l10n-ids="
+                        colors-page-override,
+                        colors-page-override-option-always.label,
+                        colors-page-override-option-auto.label,
+                        colors-page-override-option-never.label,
+                        colors-text-and-background,
+                        colors-text-header,
+                        colors-background,
+                        colors-use-system,
+                        colors-underline-links,
+                        colors-links-header,
+                        colors-unvisited-links,
+                        colors-visited-links
+                      "/>
     </hbox>
   </hbox>
 </groupbox>
+</html:section>
 
 </html:template>

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -125,6 +125,9 @@ Preferences.addAll([
   // Window Controls Position
   { id: "browser.windowControls.position", type: "wstring" },
 
+  // Menu Icon Style
+  { id: "browser.menuIcon.style", type: "int" },
+
   // Downloads
   { id: "browser.download.useDownloadDir", type: "bool" },
   { id: "browser.download.folderList", type: "int" },

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -128,6 +128,9 @@ Preferences.addAll([
   // Menu Icon Style
   { id: "browser.menuIcon.style", type: "int" },
 
+  // Bookmarks Toolbar Position
+  { id: "browser.bookmarksBar.position", type: "wstring" },
+
   // Downloads
   { id: "browser.download.useDownloadDir", type: "bool" },
   { id: "browser.download.folderList", type: "int" },

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -122,6 +122,9 @@ Preferences.addAll([
   { id: "browser.statusbar.mode", type: "int" },
   { id: "browser.statusbar.showbtn", type: "bool" },
 
+  // Window Controls Position
+  { id: "browser.windowControls.position", type: "wstring" },
+
   // Downloads
   { id: "browser.download.useDownloadDir", type: "bool" },
   { id: "browser.download.folderList", type: "int" },
@@ -2819,6 +2822,17 @@ var gMainPane = {
     var currentDirPref = Preferences.get("browser.download.dir");
     return currentDirPref.value;
   },
+
+  toggleMoveWindowControls() {
+    if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", true))
+    {
+      document.getElementById("windowControlsRadioGroup").disabled = "";
+    }
+    else
+    {
+      document.getElementById("windowControlsRadioGroup").disabled = "true";
+    }
+  }
 
 };
 

--- a/browser/components/preferences/in-content/main.xul
+++ b/browser/components/preferences/in-content/main.xul
@@ -375,6 +375,19 @@
     </radiogroup>
 </groupbox>
 
+<!-- Bookmarks Toolbar Position preferences -->
+<groupbox id="bookmarksBarPositionGroup"
+          data-category="paneGeneral"
+          hidden="true">
+  <label><html:h2 data-l10n-id="bookmarks-bar-position-header"/></label>
+    <radiogroup id="bookmarksBarPositionRadioGroup" preference="browser.bookmarksBar.position" onsyncfrompreference="moveBookmarksBar();">
+      <radio value="top"
+             data-l10n-id="top-bookmarks"/>
+      <radio value="bottom"
+             data-l10n-id="tab-bottom"/>
+    </radiogroup>
+</groupbox>
+
 <!-- Languages -->
 <groupbox id="languagesGroup" data-category="paneGeneral" hidden="true">
   <label><html:h2 data-l10n-id="language-header"/></label>

--- a/browser/components/preferences/in-content/main.xul
+++ b/browser/components/preferences/in-content/main.xul
@@ -349,6 +349,19 @@
   </vbox>
 </groupbox>
 
+<!-- Window Controls Position preferences -->
+<groupbox id="windowControlsGroup"
+          data-category="paneGeneral"
+          hidden="true">
+  <label><html:h2 data-l10n-id="window-controls-position-header"/></label>
+    <radiogroup id="windowControlsRadioGroup" preference="browser.windowControls.position" onsyncfrompreference="gMainPane.toggleMoveWindowControls(); moveWindowControls();">
+      <radio value="right"
+             data-l10n-id="right-side"/>
+      <radio value="left"
+             data-l10n-id="left-side"/>
+    </radiogroup>
+</groupbox>
+
 <!-- Languages -->
 <groupbox id="languagesGroup" data-category="paneGeneral" hidden="true">
   <label><html:h2 data-l10n-id="language-header"/></label>

--- a/browser/components/preferences/in-content/main.xul
+++ b/browser/components/preferences/in-content/main.xul
@@ -362,6 +362,19 @@
     </radiogroup>
 </groupbox>
 
+<!-- Menu Icon Style preferences -->
+<groupbox id="menuIconStyleGroup"
+          data-category="paneGeneral"
+          hidden="true">
+  <label><html:h2 data-l10n-id="menu-icon-style-header"/></label>
+    <radiogroup id="menuIconStyleRadioGroup" preference="browser.menuIcon.style" onsyncfrompreference="changeMenuIconStyle();">
+      <radio value="0"
+             data-l10n-id="menu-icon"/>
+      <radio value="1"
+             data-l10n-id="browser-icon"/>
+    </radiogroup>
+</groupbox>
+
 <!-- Languages -->
 <groupbox id="languagesGroup" data-category="paneGeneral" hidden="true">
   <label><html:h2 data-l10n-id="language-header"/></label>

--- a/browser/components/preferences/in-content/privacy.xul
+++ b/browser/components/preferences/in-content/privacy.xul
@@ -348,6 +348,44 @@
   </vbox>
 </groupbox>
 
+<!-- WebRTC peer connection -->
+<groupbox id="webrtc" data-category="panePrivacy" hidden="true">
+  <label><html:h2 data-l10n-id="webrtc-header"/></label>
+  <hbox align="center">
+    <checkbox id="media.peerconnection.enabled"
+              class="tail-with-learn-more"
+              data-l10n-id="webrtcp2preference"
+              preference="media.peerconnection.enabled"/>
+    <label class="learnMore" is="text-link" href="https://bugzilla.mozilla.org/show_bug.cgi?id=959893"
+           data-l10n-id="content-blocking-learn-more"/>
+  </hbox>
+</groupbox>
+
+<!-- HTTP Referrer Header-->
+<groupbox id="refheader" data-category="panePrivacy" hidden="true">
+   <label> <html:h2 data-l10n-id="ref-header"/></label>
+    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
+
+  <hbox align="center">
+    <label id="historyModeLabel"
+           control="doNotsendSecureXSiteReferrer"
+           data-l10n-id="history-remember-label"/>
+    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
+    <hbox>
+      <menulist id="doNotsendSecureXSiteReferrer" preference="network.http.sendRefererHeader">
+        <menupopup>
+          <menuitem data-l10n-id="sendRefererHeaderopt0"
+                    value="0"/>
+          <menuitem data-l10n-id="sendRefererHeaderopt1"
+                    value="1"/>
+          <menuitem data-l10n-id="sendRefererHeaderopt2"
+                    value="2"/>
+        </menupopup>
+      </menulist>
+    </hbox>
+  </hbox>
+</groupbox>
+
 <!-- Site Data -->
 <groupbox id="siteDataGroup" data-category="panePrivacy" hidden="true" aria-describedby="totalSiteDataSize">
   <label><html:h2 data-l10n-id="sitedata-header"/></label>
@@ -842,34 +880,6 @@
               "
               oncommand="gPrivacyPane.showScriptExceptions();"/>
     </vbox>
-  </hbox>
-
-  <hbox align="center">
-    <checkbox id="media.peerconnection.enabled"
-              class="tail-with-learn-more"
-              data-l10n-id="webrtcp2preference"
-              preference="media.peerconnection.enabled"/>
-    <label class="learnMore" is="text-link" href="https://bugzilla.mozilla.org/show_bug.cgi?id=959893"
-           data-l10n-id="content-blocking-learn-more"/>
-  </hbox>
-
-  <hbox align="center">
-    <label id="historyModeLabel"
-           control="doNotsendSecureXSiteReferrer"
-           data-l10n-id="history-remember-label"/>
-    <!-- Please don't remove the wrapping hbox/vbox/box for these elements. It's used to properly compute the search tooltip position. -->
-    <hbox>
-      <menulist id="doNotsendSecureXSiteReferrer" preference="network.http.sendRefererHeader">
-        <menupopup>
-          <menuitem data-l10n-id="sendRefererHeaderopt0"
-                    value="0"/>
-          <menuitem data-l10n-id="sendRefererHeaderopt1"
-                    value="1"/>
-          <menuitem data-l10n-id="sendRefererHeaderopt2"
-                    value="2"/>
-        </menupopup>
-      </menulist>
-    </hbox>
   </hbox>
 
 </groupbox>

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1179,3 +1179,7 @@ bookmarks-bar-position-header = Bookmarks Toolbar Position
 
 top-bookmarks =
     .label = Top
+
+pane-windowAppearance-title = Window Appearance
+
+pane-menu-title = Menu

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1166,3 +1166,11 @@ left-side =
 
 right-side =
     .label = Right Side
+
+menu-icon-style-header = Menu Icon style
+
+menu-icon =
+    .label = Menu Icon
+
+browser-icon =
+    .label = { -brand-short-name } Icon

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1174,3 +1174,8 @@ menu-icon =
 
 browser-icon =
     .label = { -brand-short-name } Icon
+
+bookmarks-bar-position-header = Bookmarks Toolbar Position
+
+top-bookmarks =
+    .label = Top

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1183,3 +1183,7 @@ top-bookmarks =
 pane-windowAppearance-title = Window Appearance
 
 pane-menu-title = Menu
+
+search-suggestions-header = Search Suggestions
+
+dnt-header = "Do Not Track” signal

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1187,3 +1187,7 @@ pane-menu-title = Menu
 search-suggestions-header = Search Suggestions
 
 dnt-header = "Do Not Track” signal
+
+webrtc-header = WebRTC peer connection
+
+ref-header = HTTP Referrer Header

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1158,3 +1158,11 @@ settings-page = Settings Page
 
 display-all-new-prefs =
     .label = Use all-new settings layout
+
+window-controls-position-header = Window Controls Position
+
+left-side =
+    .label = Left Side
+
+right-side =
+    .label = Right Side

--- a/browser/themes/linux/browser.css
+++ b/browser/themes/linux/browser.css
@@ -168,13 +168,13 @@ menuitem.bookmark-item {
   background-color: hsla(0,0%,0%,.22);
 }
 
-#TabsToolbar[brighttext] > #window-controls > #minimize-button:hover,
-#TabsToolbar[brighttext] > #window-controls > #restore-button:hover {
+:root[lwt-popup-brighttext] #window-controls #minimize-button:hover,
+:root[lwt-popup-brighttext] #window-controls #restore-button:hover {
   background-color: hsla(0,0%,100%,.12);
 }
 
-#TabsToolbar[brighttext] > #window-controls > #minimize-button:hover:active,
-#TabsToolbar[brighttext] > #window-controls > #restore-button:hover:active {
+:root[lwt-popup-brighttext] #window-controls #minimize-button:hover:active,
+:root[lwt-popup-brighttext] #window-controls #restore-button:hover:active {
   background-color: hsla(0,0%,100%,.22);
 }
 

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -533,3 +533,39 @@
 #browser-bottombox #TabsToolbar {
   background: var(--lwt-accent-color);
 }
+
+.titlebar-buttonbox-container {
+  position: absolute;
+  width: 100%;
+  top: 0;
+}
+
+.titlebar-buttonbox {
+  position: absolute;
+  right: 5px;
+  display: flex;
+}
+
+:root:not([tabsintitlebar]) .titlebar-buttonbox-container, :root[inFullscreen] .titlebar-buttonbox-container {
+  display: none;
+}
+
+:root[tabsintitlebar] #titlebar:not(.tabs-topAboveAB), :root[inFullscreen]:not([tabsintitlebar]) #titlebar:not(.tabs-topAboveAB) {
+  min-height: 30px;
+  position: relative;
+}
+
+:root[inFullscreen] #window-controls {
+  position: absolute;
+  top: 2px;
+  right: 0;
+  z-index: 1;
+}
+
+#titlebar.tabs-topAboveAB #TabsToolbar {
+  padding-right: 80px;
+}
+
+:root[inFullscreen] #titlebar.tabs-topAboveAB #TabsToolbar {
+  padding-right: 140px;
+}

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -528,6 +528,7 @@
   list-style-image: url(chrome://browser/skin/fullscreen.svg);
   margin-left: 10px;
   margin-right: 12px;
+  margin-bottom: 3px;
 }
 
 #browser-bottombox #TabsToolbar {

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -569,3 +569,32 @@
 :root[inFullscreen] #titlebar.tabs-topAboveAB #TabsToolbar {
   padding-right: 140px;
 }
+
+.titlebar-buttonbox.left {
+  left: 5px;
+  right: auto;
+}
+
+#titlebar.tabs-topAboveAB #TabsToolbar.leftWindowControls
+{
+  padding-left: 110px !important;
+}
+
+#titlebar.tabs-topAboveAB #TabsToolbar.leftWindowControls, :root[inFullscreen] #titlebar.tabs-topAboveAB #TabsToolbar.leftWindowControls
+{
+  padding-right: 0;
+}
+
+:root[inFullscreen] #titlebar.tabs-topAboveAB #TabsToolbar.leftWindowControls {
+  padding-left: 140px !important;
+}
+
+.titlebar-buttonbox.left .titlebar-close, :root[inFullscreen][tabsintitlebar] #window-controls.left #close-button {
+  order: -1;
+}
+
+:root[inFullscreen][tabsintitlebar] #window-controls.left {
+  left: 0;
+  right: auto;
+  display: flex;
+}

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -598,3 +598,7 @@
   right: auto;
   display: flex;
 }
+
+#PanelUI-menu-button.browser {
+  list-style-image: url("chrome://branding/content/icon16.png");
+}

--- a/browser/themes/shared/incontentprefs/all-new.css
+++ b/browser/themes/shared/incontentprefs/all-new.css
@@ -5,7 +5,7 @@
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 @namespace html url("http://www.w3.org/1999/xhtml");
 
-groupbox html|h2 {
+groupbox html|h2, html|section.setting-section html|h2 {
   border-bottom: 1px solid var(--in-content-border-color);
   text-transform: uppercase;
   letter-spacing: 0.4pt;
@@ -15,6 +15,9 @@ groupbox html|h2 {
 
 .main-content {
   padding-top: 24px;
+  display: flex;
+  flex: 1;
+  contain: strict;
   /* background: #343434;
   color: #cdc8c0; */
 }
@@ -33,7 +36,7 @@ groupbox html|h2 {
 }
 
 #mainPrefPane {
-  padding-top: 55px;
+  padding-top: 35px;
 }
 
 /* .navigation {
@@ -74,4 +77,65 @@ textbox {
 
 #category-all > .category-icon {
   list-style-image: url("chrome://browser/skin/preferences/in-content/all.svg");
+}
+
+.setting-group {
+  display: inline-block;
+  vertical-align: top;
+  width: 100%;
+  max-width: 220px;
+  margin: 0 18px 18px 0;
+}
+
+.setting-single {
+  margin: 0 0 3px;
+}
+
+.setting-group html|h3 {
+  margin-top: 0;
+  margin-bottom: 6px;
+}
+
+html|section.setting-section html|h2 {
+  padding-top: 24px;
+}
+
+#handlersView {
+  height: auto;
+}
+
+.pane-container {
+  flex: 1 1 auto;
+  max-width: 1400px;
+}
+
+.accessory-button
+{
+  margin-right: 5px;
+}
+
+#searchbarGroup {
+  padding-bottom: 15px;
+  margin-right: 18px;
+}
+
+html|input#downloadFolder {
+  min-width: 50ch !important;
+  margin-right: 15px;
+}
+
+#fontsGroup {
+  margin-bottom: 30px;
+}
+
+#enableOCSP {
+  padding-top: 10px;
+}
+
+html|section.setting-section[data-category="panePrivacy"] groupbox:not(.setting-group) {
+  margin: 0 18px 18px 0;
+}
+
+#trackingGroup {
+  max-width: 650px;
 }

--- a/browser/themes/windows/browser.css
+++ b/browser/themes/windows/browser.css
@@ -441,13 +441,13 @@ menuitem.bookmark-item {
   background-color: hsla(0,0%,0%,.22);
 }
 
-#TabsToolbar[brighttext] > #window-controls > #minimize-button:hover,
-#TabsToolbar[brighttext] > #window-controls > #restore-button:hover {
+:root[lwt-popup-brighttext] #window-controls #minimize-button:hover,
+:root[lwt-popup-brighttext] #window-controls #restore-button:hover {
   background-color: hsla(0,0%,100%,.12);
 }
 
-#TabsToolbar[brighttext] > #window-controls > #minimize-button:hover:active,
-#TabsToolbar[brighttext] > #window-controls > #restore-button:hover:active {
+:root[lwt-popup-brighttext] #window-controls #minimize-button:hover:active,
+:root[lwt-popup-brighttext] #window-controls #restore-button:hover:active {
   background-color: hsla(0,0%,100%,.22);
 }
 


### PR DESCRIPTION
I noticed some problems when changing Tab Bar position, so here are fixes (only tested on Linux).

Now titlebar buttons should stay on top while moving Tab Bar just like on Vivaldi. There was also problem that after enabling menu, titlebar buttons were duplicated, now fixed.