### PR TITLE
[current] Fixes to commits related to PR #1213

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1915,7 +1915,7 @@ pref("browser.pagethumbnails.capturing_disabled", false);
 // 0 - hide Status Bar
 // 1 - show Status Info Overlay
 // 2 - show Status Bar
-pref("browser.statusbar.mode", 0);
+pref("browser.statusbar.mode", 1);
 
 // Don't use buttons in zoom range control in Status Bar
 pref("browser.statusbar.showbtn", false);

--- a/toolkit/themes/shared/extensions/extensions.inc.css
+++ b/toolkit/themes/shared/extensions/extensions.inc.css
@@ -412,6 +412,19 @@ button.warning {
   -moz-box-flex: 1;
 }
 
+.privateBrowsing-notice {
+  background-color: var(--purple-70);
+  color: #fff;
+  margin: 4px 0 0;
+  padding: 4px 5px 3px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  -moz-user-focus: ignore;
+  transition-property: color, background-color;
+  transition-timing-function: var(--animation-curve);
+  transition-duration: 150ms;
+}
+
 .message-container {
   max-width: 628px;
   min-width: 628px;


### PR DESCRIPTION
**revert overzealous deletion**

https://github.com/MrAlex94/Waterfox/commit/8278142b96b4ab6ff6ae45d15557b82b2ef7d501 unintentionally removed the purple styling of the `ALLOWED IN PRIVATE WINDOWS` tags in classic `about:addons`, this just restores that CSS.

**Align default statusbar behavior with Firefox and previous Waterfox Current**

See https://github.com/MrAlex94/Waterfox/pull/1213#issuecomment-557915059