### PR TITLE
[current] misc minor cleanup

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -212,11 +212,8 @@ pref("browser.eme.ui.enabled", false);
 // UI tour experience.
 pref("browser.uitour.enabled", false, locked);
 pref("browser.uitour.loglevel", "Error", locked);
-pref("browser.uitour.requireSecure", false, locked);
 pref("browser.uitour.themeOrigin", "", locked);
 pref("browser.uitour.url", "", locked);
-// How long to show a Hearbeat survey (two hours, in seconds)
-pref("browser.uitour.surveyDuration", 7200);
 
 pref("keyword.enabled", true);
 pref("browser.fixup.domainwhitelist.localhost", true);
@@ -1817,9 +1814,6 @@ pref("browser.suppress_first_window_animation", true);
 
 // Preference that allows individual users to disable Screenshots.
 pref("extensions.screenshots.disabled", false);
-// Preference that allows individual users to leave Screenshots enabled, but
-// disable uploading to the server.
-pref("extensions.screenshots.upload-disabled", false);
 
 // URL for Learn More link for browser error logging in preferences
 pref("browser.chrome.errorReporter.infoURL",
@@ -1831,7 +1825,6 @@ pref("app.normandy.dev_mode", false, locked);
 pref("app.normandy.enabled", false, locked);
 pref("app.normandy.first_run", false, locked);
 pref("app.normandy.logging.level", 50); // Warn
-pref("app.normandy.run_interval_seconds", 21600); // 6 hours
 pref("app.normandy.shieldLearnMoreUrl", "", locked);
 #ifdef MOZ_DATA_REPORTING
 pref("app.shield.optoutstudies.enabled", false, locked);

--- a/browser/components/BrowserGlue.jsm
+++ b/browser/components/BrowserGlue.jsm
@@ -3249,24 +3249,6 @@ BrowserGlue.prototype = {
     let prefName = "browser.urlbar.matchBuckets";
     let prefValue = Services.prefs.getCharPref(prefName, "");
 
-    // Get the study (aka experiment).  It may not be installed.
-    let experiment = null;
-    let experimentName = "pref-flip-search-composition-57-release-1413565";
-    let { PreferenceExperiments } = ChromeUtils.import(
-      "resource://normandy/lib/PreferenceExperiments.jsm"
-    );
-    try {
-      experiment = await PreferenceExperiments.get(experimentName);
-    } catch (e) {}
-
-    // Uninstall the study, resetting the pref to its state before the study.
-    if (experiment && !experiment.expired) {
-      await PreferenceExperiments.stop(experimentName, {
-        resetValue: true,
-        reason: "external:search-ui-migration",
-      });
-    }
-
     // At this point, normally the pref should not exist.  If it does, then it
     // either has a user value, or something unexpectedly set its value on the
     // default branch.  Either way, preserve that value.

--- a/browser/components/newtab/lib/ASRouter.jsm
+++ b/browser/components/newtab/lib/ASRouter.jsm
@@ -35,8 +35,6 @@ ChromeUtils.defineModuleGetter(this, "ASRouterTriggerListeners",
   "resource://activity-stream/lib/ASRouterTriggerListeners.jsm");
 ChromeUtils.defineModuleGetter(this, "TelemetryEnvironment",
   "resource://gre/modules/TelemetryEnvironment.jsm");
-ChromeUtils.defineModuleGetter(this, "ClientEnvironment",
-  "resource://normandy/lib/ClientEnvironment.jsm");
 ChromeUtils.defineModuleGetter(this, "Sampling",
   "resource://gre/modules/components-utils/Sampling.jsm");
 
@@ -739,7 +737,7 @@ class _ASRouter {
     const locale = Services.locale.appLocaleAsLangTag;
 
     if (TRAILHEAD_CONFIG.LOCALES.includes(locale)) {
-      const {userId} = ClientEnvironment;
+      const {userId} = '';
       experiment = await chooseBranch(`${userId}-trailhead-experiments`, TRAILHEAD_CONFIG.EXPERIMENT_RATIOS);
 
       // For the interrupts experiment,

--- a/browser/components/newtab/lib/ActivityStream.jsm
+++ b/browser/components/newtab/lib/ActivityStream.jsm
@@ -134,7 +134,7 @@ const PREFS_CONFIG = new Map([
   }],
   ["section.highlights.includePocket", {
     title: "Boolean flag that decides whether or not to show saved Pocket stories in highlights.",
-    value: true,
+    value: false,
   }],
   ["section.highlights.includeDownloads", {
     title: "Boolean flag that decides whether or not to show saved recent Downloads in highlights.",

--- a/browser/components/newtab/lib/SectionsManager.jsm
+++ b/browser/components/newtab/lib/SectionsManager.jsm
@@ -27,7 +27,7 @@ const BUILT_IN_SECTIONS = {
         icon: "icon-info",
       }] : [],
     },
-    shouldHidePref: options.hidden,
+    shouldHidePref: true,
     eventSource: "TOP_STORIES",
     icon: options.provider_icon,
     title: {id: "header_recommended_by", values: {provider: options.provider_name}},

--- a/browser/components/newtab/lib/SectionsManager.jsm
+++ b/browser/components/newtab/lib/SectionsManager.jsm
@@ -63,9 +63,6 @@ const BUILT_IN_SECTIONS = {
       }, {
         name: "section.highlights.includeDownloads",
         titleString: "prefs_highlights_options_download_label",
-      }, {
-        name: "section.highlights.includePocket",
-        titleString: "prefs_highlights_options_pocket_label",
       }],
     },
     shouldHidePref:  false,

--- a/browser/components/uitour/UITour.jsm
+++ b/browser/components/uitour/UITour.jsm
@@ -980,7 +980,7 @@ var UITour = {
   // This function is copied to UITourListener.
   isSafeScheme(aURI) {
     let allowedSchemes = new Set(["https", "about"]);
-    if (!Services.prefs.getBoolPref("browser.uitour.requireSecure")) {
+    if (!Services.prefs.getBoolPref("browser.uitour.requireSecure", true)) {
       allowedSchemes.add("http");
     }
 

--- a/browser/components/uitour/UITourChild.jsm
+++ b/browser/components/uitour/UITourChild.jsm
@@ -56,7 +56,7 @@ class UITourChild extends ActorChild {
   // This function is copied from UITour.jsm.
   isSafeScheme(aURI) {
     let allowedSchemes = new Set(["https", "about"]);
-    if (!Services.prefs.getBoolPref("browser.uitour.requireSecure")) {
+    if (!Services.prefs.getBoolPref("browser.uitour.requireSecure", true)) {
       allowedSchemes.add("http");
     }
 

--- a/browser/extensions/screenshots/experiments/screenshots/api.js
+++ b/browser/extensions/screenshots/experiments/screenshots/api.js
@@ -94,7 +94,7 @@ this.screenshots = class extends ExtensionAPI {
             return Services.prefs.getBoolPref("places.history.enabled", true);
           },
           isUploadDisabled() {
-            return Services.prefs.getBoolPref("extensions.screenshots.upload-disabled", false);
+            return true;
           },
           initLibraryButton() {
             context.callOnClose({

--- a/devtools/client/webide/preferences/webide.js
+++ b/devtools/client/webide/preferences/webide.js
@@ -3,7 +3,7 @@
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 pref("devtools.webide.templatesURL", "https://code.cdn.mozilla.net/templates/list.json");
-pref("devtools.webide.autoinstallADBExtension", true);
+pref("devtools.webide.autoinstallADBExtension", false);
 pref("devtools.webide.autoConnectRuntime", true);
 pref("devtools.webide.restoreLastProject", true);
 pref("devtools.webide.enableLocalRuntime", false);

--- a/toolkit/components/moz.build
+++ b/toolkit/components/moz.build
@@ -115,8 +115,6 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] != 'android':
         'components.conf',
     ]
 
-if CONFIG['MOZ_BUILD_APP'] == 'browser':
-    DIRS += ['normandy']
 
 # This is only packaged for browser since corrupt JAR and XPI files tend to be a desktop-OS problem.
 if CONFIG['MOZ_BUILD_APP'] == 'browser':


### PR DESCRIPTION
**Disable building leftover shield component**

Waterfox already hard-disables / doesn't have Shield.  This also gets rid of the dead `about:studies` page and unused Shield-related code from Waterfox builds.

**Disable silent auto-install of WebIDE-related extension**

Tag https://github.com/MrAlex94/Waterfox/issues/515 .  In addition to what was said there, Waterfox Current also offers a button in `about:debugging` to install this addon ("Enable USB Devices").  There's no need for it to be _silently_ installed.

**Get rid of some moot about:config listings**

The code that uses these prefs isn't even being called at all in Waterfox.  They are just clutter in `about:config`, making users think something is there to be configured when it's actually not.

Additionally, in the case of `extensions.screenshots.upload-disabled`, Firefox disabled the upload service in Firefox 67 and the upload service was shut down anyway.


**Remove "Pages saved to Pocket" preference UI and default the pref to false**
**Don't show preferences UI for hard-disabled "Recommended by Pocket"**

These two commits get rid of dead Pocket-related preferences UI from `about:preferences#home`.