### PR TITLE
[Classic] Don't position floats in a nowrap context until hitting a break opportunity.

### DIFF
--- a/layout/generic/BlockReflowInput.h
+++ b/layout/generic/BlockReflowInput.h
@@ -380,6 +380,10 @@ public:
   // being N^2.
   nsFloatCacheFreeList mBelowCurrentLineFloats;
 
+  // The list of floats that are waiting on a break opportunity in order to be
+  // placed, since we're on a nowrap context.
+  nsTArray<nsIFrame*> mNoWrapFloats;
+
   nscoord mMinLineHeight;
 
   int32_t mLineNumber;

--- a/layout/generic/nsBlockFrame.cpp
+++ b/layout/generic/nsBlockFrame.cpp
@@ -3908,6 +3908,7 @@ nsBlockFrame::ReflowInlineFrames(BlockReflowInput& aState,
           aState.FloatManager()->PopState(&floatManagerState);
           // Clear out float lists
           aState.mCurrentLineFloats.DeleteAll();
+          MOZ_ASSERT(aState.mNoWrapFloats.IsEmpty());
           aState.mBelowCurrentLineFloats.DeleteAll();
         }
 
@@ -4539,6 +4540,9 @@ nsBlockFrame::PlaceLine(BlockReflowInput& aState,
                         nscoord& aAvailableSpaceBSize,
                         bool* aKeepReflowGoing)
 {
+  // Try to position the floats in a nowrap context.
+  aLineLayout.FlushNoWrapFloats();
+
   // Trim extra white-space from the line before placing the frames
   aLineLayout.TrimTrailingWhiteSpace();
 

--- a/layout/generic/nsLineLayout.cpp
+++ b/layout/generic/nsLineLayout.cpp
@@ -951,7 +951,18 @@ nsLineLayout::ReflowFrame(nsIFrame* aFrame,
       nsIFrame* outOfFlowFrame = nsLayoutUtils::GetFloatFromPlaceholder(aFrame);
       if (outOfFlowFrame) {
         if (psd->mNoWrap &&
-            !LineIsEmpty() && // We can always place floats in an empty line.
+            // We can always place floats in an empty line.
+            !LineIsEmpty() &&
+            // We always place floating letter frames. This kinda sucks. They'd
+            // usually fall into the LineIsEmpty() check anyway, except when
+            // there's something like a bullet before or what not. We actually
+            // need to place them now, because they're pretty nasty and they
+            // create continuations that are in flow and not a kid of the
+            // previous continuation's parent. We don't want the deferred reflow
+            // of the letter frame to kill a continuation after we've stored it
+            // in the line layout data structures. See bug 1490281 to fix the
+            // underlying issue. When that's fixed this check should be removed.
+            !outOfFlowFrame->IsLetterFrame() &&
             !GetOutermostLineLayout()->mBlockRI->mFlags.mCanHaveTextOverflow) {
           // We'll do this at the next break opportunity.
           RecordNoWrapFloat(outOfFlowFrame);

--- a/layout/generic/nsLineLayout.cpp
+++ b/layout/generic/nsLineLayout.cpp
@@ -255,6 +255,8 @@ nsLineLayout::EndLineReflow()
                 !mFramesAllocated && !mFramesFreed && !mFrameFreeList),
                "Allocated frames or spans on non-base line layout?");
 
+  MOZ_ASSERT(mRootSpan == mCurrentSpan);
+
   UnlinkFrame(mRootSpan->mFrame);
   mCurrentSpan = mRootSpan = nullptr;
 
@@ -447,6 +449,12 @@ nsLineLayout::EndSpan(nsIFrame* aFrame)
   printf(": EndSpan width=%d\n", mCurrentSpan->mICoord - mCurrentSpan->mIStart);
 #endif
   PerSpanData* psd = mCurrentSpan;
+  MOZ_ASSERT(psd->mParent, "We never call this on the root");
+
+  if (psd->mNoWrap && !psd->mParent->mNoWrap) {
+    FlushNoWrapFloats();
+  }
+
   nscoord iSizeResult = psd->mLastFrame ? (psd->mICoord - psd->mIStart) : 0;
 
   mSpanDepth--;
@@ -942,27 +950,14 @@ nsLineLayout::ReflowFrame(nsIFrame* aFrame,
       pfd->mSkipWhenTrimmingWhitespace = true;
       nsIFrame* outOfFlowFrame = nsLayoutUtils::GetFloatFromPlaceholder(aFrame);
       if (outOfFlowFrame) {
-        // Add mTrimmableISize to the available width since if the line ends
-        // here, the width of the inline content will be reduced by
-        // mTrimmableISize.
-        nscoord availableISize = psd->mIEnd - (psd->mICoord - mTrimmableISize);
-        if (psd->mNoWrap) {
-          // If we place floats after inline content where there's
-          // no break opportunity, we don't know how much additional
-          // width is required for the non-breaking content after the float,
-          // so we can't know whether the float plus that content will fit
-          // on the line. So for now, don't place floats after inline
-          // content where there's no break opportunity. This is incorrect
-          // but hopefully rare. Fixing it will require significant
-          // restructuring of line layout.
-          // We might as well allow zero-width floats to be placed, though.
-          availableISize = 0;
+        if (psd->mNoWrap &&
+            !LineIsEmpty() && // We can always place floats in an empty line.
+            !GetOutermostLineLayout()->mBlockRI->mFlags.mCanHaveTextOverflow) {
+          // We'll do this at the next break opportunity.
+          RecordNoWrapFloat(outOfFlowFrame);
+        } else {
+          placedFloat = TryToPlaceFloat(outOfFlowFrame);
         }
-        placedFloat = GetOutermostLineLayout()->
-          AddFloat(outOfFlowFrame, availableISize);
-        NS_ASSERTION(!(outOfFlowFrame->IsLetterFrame() &&
-                       GetFirstLetterStyleOK()),
-                    "FirstLetterStyle set on line with floating first letter");
       }
     }
     else if (isText) {
@@ -1108,8 +1103,8 @@ nsLineLayout::ReflowFrame(nsIFrame* aFrame,
         VerticalAlignFrames(span);
       }
 
-      if (!continuingTextRun) {
-        if (!psd->mNoWrap && (!LineIsEmpty() || placedFloat)) {
+      if (!continuingTextRun && !psd->mNoWrap) {
+        if (!LineIsEmpty() || placedFloat) {
           // record soft break opportunity after this content that can't be
           // part of a text run. This is not a text frame so we know
           // that offset INT32_MAX means "after the content".
@@ -1491,6 +1486,60 @@ nsLineLayout::DumpPerSpanData(PerSpanData* psd, int32_t aIndent)
   }
 }
 #endif
+
+void
+nsLineLayout::RecordNoWrapFloat(nsIFrame* aFloat)
+{
+  GetOutermostLineLayout()->mBlockRI->mNoWrapFloats.AppendElement(aFloat);
+}
+
+void
+nsLineLayout::FlushNoWrapFloats()
+{
+  auto& noWrapFloats = GetOutermostLineLayout()->mBlockRI->mNoWrapFloats;
+  for (nsIFrame* floatedFrame : noWrapFloats) {
+    TryToPlaceFloat(floatedFrame);
+  }
+  noWrapFloats.Clear();
+}
+
+bool
+nsLineLayout::TryToPlaceFloat(nsIFrame* aFloat)
+{
+  // Add mTrimmableISize to the available width since if the line ends here, the
+  // width of the inline content will be reduced by mTrimmableISize.
+  nscoord availableISize = mCurrentSpan->mIEnd - (mCurrentSpan->mICoord - mTrimmableISize);
+  NS_ASSERTION(!(aFloat->IsLetterFrame() && GetFirstLetterStyleOK()),
+              "FirstLetterStyle set on line with floating first letter");
+  return GetOutermostLineLayout()->AddFloat(aFloat, availableISize);
+}
+
+bool
+nsLineLayout::NotifyOptionalBreakPosition(nsIFrame* aFrame,
+                                          int32_t aOffset,
+                                          bool aFits,
+                                          gfxBreakPriority aPriority)
+{
+  MOZ_ASSERT(!aFits || !mNeedBackup,
+             "Shouldn't be updating the break position with a break that fits "
+             "after we've already flagged an overrun");
+  MOZ_ASSERT(mCurrentSpan, "Should be doing line layout");
+  if (mCurrentSpan->mNoWrap) {
+    FlushNoWrapFloats();
+  }
+
+  // Remember the last break position that fits; if there was no break that fit,
+  // just remember the first break
+  if ((aFits && aPriority >= mLastOptionalBreakPriority) ||
+      !mLastOptionalBreakFrame) {
+    mLastOptionalBreakFrame = aFrame;
+    mLastOptionalBreakFrameOffset = aOffset;
+    mLastOptionalBreakPriority = aPriority;
+  }
+  return aFrame && mForceBreakFrame == aFrame &&
+    mForceBreakFrameOffset == aOffset;
+}
+
 
 #define VALIGN_OTHER  0
 #define VALIGN_TOP    1

--- a/layout/generic/nsLineLayout.h
+++ b/layout/generic/nsLineLayout.h
@@ -259,21 +259,21 @@ public:
    * @return true if we are actually reflowing with forced break position and we
    * should break here
    */
-  bool NotifyOptionalBreakPosition(nsIFrame* aFrame, int32_t aOffset,
-                                   bool aFits, gfxBreakPriority aPriority) {
-    NS_ASSERTION(!aFits || !mNeedBackup,
-                  "Shouldn't be updating the break position with a break that fits after we've already flagged an overrun");
-    // Remember the last break position that fits; if there was no break that fit,
-    // just remember the first break
-    if ((aFits && aPriority >= mLastOptionalBreakPriority) ||
-        !mLastOptionalBreakFrame) {
-      mLastOptionalBreakFrame = aFrame;
-      mLastOptionalBreakFrameOffset = aOffset;
-      mLastOptionalBreakPriority = aPriority;
-    }
-    return aFrame && mForceBreakFrame == aFrame &&
-      mForceBreakFrameOffset == aOffset;
-  }
+  bool NotifyOptionalBreakPosition(nsIFrame* aFrame,
+                                   int32_t aOffset,
+                                   bool aFits,
+                                   gfxBreakPriority aPriority);
+
+  // Tries to place a float, and records whether the float actually was placed.
+  bool TryToPlaceFloat(nsIFrame* aFloat);
+
+  // Records a floating frame in a nowrap context for it to be placed on the
+  // next break opportunity.
+  void RecordNoWrapFloat(nsIFrame* aFloat);
+
+  // Tries to place the floats from the nowrap context.
+  void FlushNoWrapFloats();
+
   /**
    * Like NotifyOptionalBreakPosition, but here it's OK for mNeedBackup
    * to be set, because the caller is merely pruning some saved break position(s)

--- a/layout/reftests/bugs/reftest.list
+++ b/layout/reftests/bugs/reftest.list
@@ -1151,7 +1151,7 @@ fuzzy-if(skiaContent,1,3280) == 438987-2c.html 438987-2-ref.html
 fuzzy-if(skiaContent,1,1) == 440112.html 440112-ref.html
 == 440149-1.html 440149-1-ref.html
 == 441259-1.html 441259-1-ref.html
-fails-if(!styloVsGecko) == 441259-2.html 441259-2-ref.html # bug 441400
+fails-if(!styloVsGecko) == 441259-2.html 441259-2-ref.html
 fuzzy-if(skiaContent,1,3) == 442542-1.html 442542-1-ref.html
 == 444015-1.html 444015-1-ref.html
 == 444375-1.html 444375-1-ref.html

--- a/layout/reftests/css-grid/grid-container-baselines-003-ref.html
+++ b/layout/reftests/css-grid/grid-container-baselines-003-ref.html
@@ -87,7 +87,7 @@ A<div class="ib">
 <div class="ib" style="width:200px;">
   <div class="ib" style="height:120px; width:76px; white-space:nowrap"><span
      class="a f" style="width:30px; margin-top:7px; padding-top:5px; padding-bottom:18px;">A<br>B</span><span
-     class="a f" style="float:right; width:30px; position:relative; left:-4px; padding-bottom:22px; margin-top:-100px">A<br>B</span>
+     class="a f" style="float:right; width:30px; position:relative; left:-4px; padding-bottom:22px;">A<br>B</span>
   </div><span class="i a f" style="width:54px">C<br>D</span><span
      class="a f" style="width:54px; padding-top:20px;">E<br>F</span>
 </div>


### PR DESCRIPTION
That fixes bug which I noticed in my team's extension (Polish Cookie Consent). I pushed new version to AMO and forgot to check how it looks like on Waterfox Classic, but didn't expected that thing may happen...

Before
![before](https://user-images.githubusercontent.com/19818572/70855537-a0e8e280-1ecc-11ea-9fee-51f55f72acaf.png)

After
![after](https://user-images.githubusercontent.com/19818572/70855560-118fff00-1ecd-11ea-918f-d7ed00e1a1e7.png)

