### PR TITLE
[Current] Bug 1574056 - Make `mach vendor rust` use now native `cargo vendor`

### DIFF
--- a/python/mozbuild/mozbuild/vendor_rust.py
+++ b/python/mozbuild/mozbuild/vendor_rust.py
@@ -29,31 +29,13 @@ class VendorRust(MozbuildObject):
 
     def check_cargo_version(self, cargo):
         '''
-        Ensure that cargo is new enough. cargo 0.12 added support
-        for source replacement, which is required for vendoring to work.
+        Ensure that cargo is new enough. cargo 1.37 added support
+        for the vendor command.
         '''
         out = subprocess.check_output([cargo, '--version']).splitlines()[0]
         if not out.startswith('cargo'):
             return False
-        return LooseVersion(out.split()[1]) >= b'0.13'
-
-    def check_cargo_vendor_version(self, cargo):
-        '''
-        Ensure that cargo-vendor is new enough. cargo-vendor 0.1.13 and newer
-        strips out .cargo-ok, .orig and .rej files, and deals with [patch]
-        replacements in Cargo.toml files which we want.  Version 0.1.14 and up
-        handles local modifications to vendored crates (bug 1323557).
-        '''
-        for l in subprocess.check_output([cargo, 'install', '--list']).splitlines():
-            # The line looks like one of the following:
-            #  cargo-vendor v0.1.12:
-            #  cargo-vendor v0.1.12 (file:///path/to/local/build/cargo-vendor):
-            # and we want to extract the version part of it
-            m = re.match('cargo-vendor v((\d+\.)*\d+)', l)
-            if m:
-                version = m.group(1)
-                return LooseVersion(version) >= b'0.1.23'
-        return False
+        return LooseVersion(out.split()[1]) >= b'1.37'
 
     def check_modified_files(self):
         '''
@@ -108,23 +90,10 @@ Please commit or stash these changes before vendoring, or re-run with `--ignore-
         '''
         cargo = self.get_cargo_path()
         if not self.check_cargo_version(cargo):
-            self.log(logging.ERROR, 'cargo_version', {}, 'Cargo >= 0.13 required (install Rust 1.12 or newer)')
+            self.log(logging.ERROR, 'cargo_version', {}, 'Cargo >= 1.37 required (install Rust 1.37 or newer)')
             return None
         else:
             self.log(logging.DEBUG, 'cargo_version', {}, 'cargo is new enough')
-        have_vendor = any(l.strip() == 'vendor' for l in subprocess.check_output([cargo, '--list']).splitlines())
-        if not have_vendor:
-            self.log(logging.INFO, 'installing', {}, 'Installing cargo-vendor (this may take a few minutes)...')
-            env = self.check_openssl()
-            self.run_process(args=[cargo, 'install', 'cargo-vendor'],
-                             append_env=env)
-        elif not self.check_cargo_vendor_version(cargo):
-            self.log(logging.INFO, 'cargo_vendor', {}, 'cargo-vendor >= 0.1.23 required; force-reinstalling (this may take a few minutes)...')
-            env = self.check_openssl()
-            self.run_process(args=[cargo, 'install', '--force', 'cargo-vendor'],
-                             append_env=env)
-        else:
-            self.log(logging.DEBUG, 'cargo_vendor', {}, 'sufficiently new cargo-vendor is already installed')
 
         return cargo
 
@@ -332,7 +301,7 @@ license file's hash.
         # We do an |update -p| here to regenerate the Cargo.lock file with minimal changes. See bug 1324462
         subprocess.check_call([cargo, 'update', '-p', 'gkrust'], cwd=self.topsrcdir)
 
-        subprocess.check_call([cargo, 'vendor', '--quiet', '--sync', 'Cargo.lock'] + [vendor_dir], cwd=self.topsrcdir)
+        subprocess.check_call([cargo, 'vendor', '--quiet', vendor_dir], cwd=self.topsrcdir)
 
         if not self._check_licenses(vendor_dir):
             self.log(logging.ERROR, 'license_check_failed', {},

--- a/python/mozbuild/mozpack/path.py
+++ b/python/mozbuild/mozpack/path.py
@@ -28,8 +28,21 @@ def normsep(path):
         path = path.replace(os.altsep, '/')
     return path
 
+def cargo_workaround(path):
+    unc = '//?/'
+    if path.startswith(unc):
+        return path[len(unc):]
+    return path
+
 
 def relpath(path, start):
+    path = normsep(path)
+    start = normsep(start)
+    if sys.platform == 'win32':
+        # os.path.relpath can't handle relative paths between UNC and non-UNC
+        # paths, so strip a //?/ prefix if present (bug 1581248)
+        path = cargo_workaround(path)
+        start = cargo_workaround(start)
     rel = normsep(os.path.relpath(path, start))
     return '' if rel == '.' else rel
 


### PR DESCRIPTION
Fixes running `mach vendor rust` command with Rust 1.37+, might be useful in the future :smile: