### PR TITLE
[Classic] Don't return null from getComputedStyle when there's no presentation.

### DIFF
--- a/dom/base/AnonymousContent.cpp
+++ b/dom/base/AnonymousContent.cpp
@@ -228,7 +228,9 @@ AnonymousContent::GetComputedStylePropertyValue(const nsAString& aElementId,
   }
 
   RefPtr<nsComputedDOMStyle> cs =
-    new nsComputedDOMStyle(element, NS_LITERAL_STRING(""), shell,
+    new nsComputedDOMStyle(element,
+                           NS_LITERAL_STRING(""),
+                           element->OwnerDoc(),
                            nsComputedDOMStyle::eAll);
   aRv = cs->GetPropertyValue(aPropertyName, aResult);
 }

--- a/dom/base/nsDOMWindowUtils.cpp
+++ b/dom/base/nsDOMWindowUtils.cpp
@@ -3012,7 +3012,7 @@ nsDOMWindowUtils::GetUnanimatedComputedStyle(nsIDOMElement* aElement,
        computedValue.GetCSSValueValue()->GetUnit() == eCSSUnit_Inherit)) {
     RefPtr<nsComputedDOMStyle> computedStyle =
       NS_NewComputedDOMStyle(
-       element, aPseudoElement, shell,
+       element, aPseudoElement, element->OwnerDoc(),
        nsComputedDOMStyle::StyleType::eAll,
        nsComputedDOMStyle::AnimationFlag::eWithoutAnimation);
     computedStyle->GetPropertyValue(propertyID, aResult);

--- a/dom/base/nsGlobalWindow.cpp
+++ b/dom/base/nsGlobalWindow.cpp
@@ -11284,35 +11284,12 @@ nsGlobalWindow::GetComputedStyleHelperOuter(Element& aElt,
 {
   MOZ_RELEASE_ASSERT(IsOuterWindow());
 
-  if (!mDocShell) {
+  if (!mDoc) {
     return nullptr;
   }
 
-  nsCOMPtr<nsIPresShell> presShell = mDocShell->GetPresShell();
-
-  if (!presShell) {
-    // Try flushing frames on our parent in case there's a pending
-    // style change that will create the presshell.
-    auto* parent = nsGlobalWindow::Cast(GetPrivateParent());
-    if (!parent) {
-      return nullptr;
-    }
-
-    parent->FlushPendingNotifications(FlushType::Frames);
-
-    // Might have killed mDocShell
-    if (!mDocShell) {
-      return nullptr;
-    }
-
-    presShell = mDocShell->GetPresShell();
-    if (!presShell) {
-      return nullptr;
-    }
-  }
-
   RefPtr<nsComputedDOMStyle> compStyle =
-    NS_NewComputedDOMStyle(&aElt, aPseudoElt, presShell,
+    NS_NewComputedDOMStyle(&aElt, aPseudoElt, mDoc,
                            aDefaultStylesOnly ? nsComputedDOMStyle::eDefaultOnly :
                                                 nsComputedDOMStyle::eAll);
 

--- a/editor/libeditor/CSSEditUtils.cpp
+++ b/editor/libeditor/CSSEditUtils.cpp
@@ -568,11 +568,8 @@ CSSEditUtils::GetComputedStyle(Element* aElement)
   nsIDocument* doc = aElement->GetUncomposedDoc();
   NS_ENSURE_TRUE(doc, nullptr);
 
-  nsIPresShell* presShell = doc->GetShell();
-  NS_ENSURE_TRUE(presShell, nullptr);
-
   RefPtr<nsComputedDOMStyle> style =
-    NS_NewComputedDOMStyle(aElement, EmptyString(), presShell);
+    NS_NewComputedDOMStyle(aElement, EmptyString(), doc);
 
   return style.forget();
 }

--- a/layout/style/nsComputedDOMStyle.cpp
+++ b/layout/style/nsComputedDOMStyle.cpp
@@ -346,7 +346,6 @@ nsComputedDOMStyle::SetCssText(const nsAString& aCssText)
 NS_IMETHODIMP
 nsComputedDOMStyle::GetLength(uint32_t* aLength)
 {
-  NS_PRECONDITION(aLength, "Null aLength!  Prepare to die!");
 
   uint32_t length = GetComputedStyleMap()->Length();
 
@@ -357,6 +356,8 @@ nsComputedDOMStyle::GetLength(uint32_t* aLength)
     length += mStyleContext->IsServo()
       ? Servo_GetCustomPropertiesCount(mStyleContext->AsServo())
       : StyleVariables()->mVariables.Count();
+  } else {
+    length = 0;
   }
 
   *aLength = length;
@@ -1034,7 +1035,6 @@ nsComputedDOMStyle::GetPropertyCSSValue(const nsAString& aPropertyName, ErrorRes
 
   UpdateCurrentStyleSources(needsLayoutFlush);
   if (!mStyleContext) {
-    aRv.Throw(NS_ERROR_NOT_AVAILABLE);
     return nullptr;
   }
 

--- a/layout/style/nsComputedDOMStyle.cpp
+++ b/layout/style/nsComputedDOMStyle.cpp
@@ -66,14 +66,15 @@ using namespace mozilla::dom;
  */
 
 already_AddRefed<nsComputedDOMStyle>
-NS_NewComputedDOMStyle(dom::Element* aElement, const nsAString& aPseudoElt,
-                       nsIPresShell* aPresShell,
+NS_NewComputedDOMStyle(dom::Element* aElement,
+                       const nsAString& aPseudoElt,
+                       nsIDocument* aDocument,
                        nsComputedDOMStyle::StyleType aStyleType,
                        nsComputedDOMStyle::AnimationFlag aFlag)
 {
   RefPtr<nsComputedDOMStyle> computedStyle;
   computedStyle = new nsComputedDOMStyle(aElement, aPseudoElt,
-                                         aPresShell, aStyleType, aFlag);
+                                         aDocument, aStyleType, aFlag);
   return computedStyle.forget();
 }
 
@@ -246,7 +247,7 @@ nsComputedStyleMap::Update()
 
 nsComputedDOMStyle::nsComputedDOMStyle(dom::Element* aElement,
                                        const nsAString& aPseudoElt,
-                                       nsIPresShell* aPresShell,
+                                       nsIDocument* aDocument,
                                        StyleType aStyleType,
                                        AnimationFlag aFlag)
   : mDocumentWeak(nullptr)
@@ -259,13 +260,13 @@ nsComputedDOMStyle::nsComputedDOMStyle(dom::Element* aElement,
   , mResolvedStyleContext(false)
   , mAnimationFlag(aFlag)
 {
-  MOZ_ASSERT(aElement && aPresShell);
-
-  mDocumentWeak = do_GetWeakReference(aPresShell->GetDocument());
+  MOZ_ASSERT(aElement);
+  MOZ_ASSERT(aDocument);
+  // TODO(emilio, bug 548397, https://github.com/w3c/csswg-drafts/issues/2403):
+  // Should use aElement->OwnerDoc() instead.
+  mDocumentWeak = do_GetWeakReference(aDocument);
   mContent = aElement;
   mPseudo = nsCSSPseudoElements::GetPseudoAtom(aPseudoElt);
-
-  MOZ_ASSERT(aPresShell->GetPresContext());
 }
 
 nsComputedDOMStyle::~nsComputedDOMStyle()

--- a/layout/style/nsComputedDOMStyle.h
+++ b/layout/style/nsComputedDOMStyle.h
@@ -81,7 +81,7 @@ public:
 
   nsComputedDOMStyle(mozilla::dom::Element* aElement,
                      const nsAString& aPseudoElt,
-                     nsIPresShell* aPresShell,
+                     nsIDocument* aDocument,
                      StyleType aStyleType,
                      AnimationFlag aFlag = eWithAnimation);
 
@@ -793,7 +793,7 @@ private:
 already_AddRefed<nsComputedDOMStyle>
 NS_NewComputedDOMStyle(mozilla::dom::Element* aElement,
                        const nsAString& aPseudoElt,
-                       nsIPresShell* aPresShell,
+                       nsIDocument* aDocument,
                        nsComputedDOMStyle::StyleType aStyleType =
                          nsComputedDOMStyle::eAll,
                        nsComputedDOMStyle::AnimationFlag aFlag =

--- a/layout/style/nsComputedDOMStyle.h
+++ b/layout/style/nsComputedDOMStyle.h
@@ -85,9 +85,9 @@ public:
                      StyleType aStyleType,
                      AnimationFlag aFlag = eWithAnimation);
 
-  virtual nsINode *GetParentObject() override
+  nsINode* GetParentObject() override
   {
-    return mContent;
+    return mElement;
   }
 
   static already_AddRefed<nsStyleContext>
@@ -720,9 +720,9 @@ private:
 
   // We don't really have a good immutable representation of "presentation".
   // Given the way GetComputedStyle is currently used, we should just grab the
-  // 0th presshell, if any, from the document.
+  // presshell, if any, from the document.
   nsWeakPtr mDocumentWeak;
-  nsCOMPtr<nsIContent> mContent;
+  RefPtr<mozilla::dom::Element> mElement;
 
   /**
    * Strong reference to the style context we access data from.  This can be
@@ -744,13 +744,13 @@ private:
   nsCOMPtr<nsIAtom> mPseudo;
 
   /*
-   * While computing style data, the primary frame for mContent --- named "outer"
+   * While computing style data, the primary frame for mElement --- named "outer"
    * because we should use it to compute positioning data.  Null
    * otherwise.
    */
   nsIFrame* mOuterFrame;
   /*
-   * While computing style data, the "inner frame" for mContent --- the frame
+   * While computing style data, the "inner frame" for mElement --- the frame
    * which we should use to compute margin, border, padding and content data.  Null
    * otherwise.
    */


### PR DESCRIPTION
This fixes problem mentioned on https://github.com/MoonchildProductions/UXP/issues/1219.