### PR TITLE
[Classic] Revert "Enable service workers when notifications enabled"

### DIFF
--- a/browser/components/preferences/in-content/content.js
+++ b/browser/components/preferences/in-content/content.js
@@ -339,15 +339,4 @@ var gContentPane = {
   toggleDoNotDisturbNotifications(event) {
     AlertsServiceDND.manualDoNotDisturb = event.target.checked;
   },
-
-  toggleServiceWorkers() {
-    if (Services.prefs.getBoolPref("dom.webnotifications.enabled", true))
-    {
-      Services.prefs.setBoolPref("dom.serviceWorkers.enabled", true);
-    }
-    else
-    {
-      Services.prefs.setBoolPref("dom.serviceWorkers.enabled", false);
-    }
-  }
 };

--- a/browser/components/preferences/in-content/content.xul
+++ b/browser/components/preferences/in-content/content.xul
@@ -90,7 +90,6 @@
       <row id="notificationsPolicyRow" align="center">
         <hbox align="start">
           <checkbox id="enableNotifications" preference="dom.webnotifications.enabled"
-                    onsyncfrompreference="gContentPane.toggleServiceWorkers();"
                     label="&enableNotifications.label;"/>
           <label id="notificationsPolicyLearnMore"
                  class="learnMore text-link"


### PR DESCRIPTION
This probably fixes #1331.
That was rather bad idea, seems I forgot about one thing, notifications are enabled by default. 
Alternative solution is to disable notifications by default, but seems that's rather not that good idea, cuz despite that service workers are disabled, still some desktop notifications might work.