### PR TITLE
[Classic] Enable unprefixed Fullscreen API by default.

### DIFF
--- a/dom/bindings/BindingUtils.cpp
+++ b/dom/bindings/BindingUtils.cpp
@@ -874,7 +874,8 @@ CreateInterfacePrototypeObject(JSContext* cx, JS::Handle<JSObject*> global,
   }
 
   if (unscopableNames) {
-    JS::Rooted<JSObject*> unscopableObj(cx, JS_NewPlainObject(cx));
+    JS::Rooted<JSObject*> unscopableObj(cx,
+      JS_NewObjectWithGivenProto(cx, nullptr, nullptr));
     if (!unscopableObj) {
       return nullptr;
     }

--- a/dom/webidl/Document.webidl
+++ b/dom/webidl/Document.webidl
@@ -232,7 +232,7 @@ partial interface Document {
 partial interface Document {
   // Note: Per spec the 'S' in these two is lowercase, but the "Moz"
   // versions have it uppercase.
-  [LenientSetter, Func="nsDocument::IsUnprefixedFullscreenEnabled"]
+  [LenientSetter, Unscopable, Func="nsDocument::IsUnprefixedFullscreenEnabled"]
   readonly attribute boolean fullscreen;
   [BinaryName="fullscreen"]
   readonly attribute boolean mozFullScreen;

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5013,11 +5013,7 @@ pref("alerts.showFavicons", false);
 
 // DOM full-screen API.
 pref("full-screen-api.enabled", false);
-#ifdef RELEASE_OR_BETA
-pref("full-screen-api.unprefix.enabled", false);
-#else
 pref("full-screen-api.unprefix.enabled", true);
-#endif
 pref("full-screen-api.allow-trusted-requests-only", true);
 pref("full-screen-api.pointer-lock.enabled", true);
 // transition duration of fade-to-black and fade-from-black, unit: ms


### PR DESCRIPTION
Fixes problem mentioned on https://www.reddit.com/r/waterfox/comments/eimh20/videos_not_playing_in_classic/.

Basilisk has also other related prefs changed => https://github.com/MoonchildProductions/UXP/commit/acd4eee44eb04fe01b0063818b492390f463ccec, maybe it's worth to do the same?