### PR TITLE
[current] More fixes to PR #1289

### DIFF
--- a/browser/components/preferences/in-content-all-new/appearance.js
+++ b/browser/components/preferences/in-content-all-new/appearance.js
@@ -37,7 +37,7 @@ var gAppearancePane = {
         this.setInitialized();
     },
     toggleMoveWindowControls() {
-      if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", true))
+      if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", window.matchMedia("(-moz-gtk-csd-hide-titlebar-by-default)").matches))
       {
         document.getElementById("windowControlsRadioGroup").disabled = "";
       }

--- a/browser/components/preferences/in-content/main.js
+++ b/browser/components/preferences/in-content/main.js
@@ -2830,7 +2830,7 @@ var gMainPane = {
   },
 
   toggleMoveWindowControls() {
-    if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", true))
+    if(Services.prefs.getBoolPref("browser.tabs.drawInTitlebar", window.matchMedia("(-moz-gtk-csd-hide-titlebar-by-default)").matches))
     {
       document.getElementById("windowControlsRadioGroup").disabled = "";
     }

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -604,7 +604,7 @@
 }
 
 :root[tabsintitlebar][leftWindowControls] #toolbar-menubar {
-  padding-left: 85px;
+  padding-left: 100px;
 }
 
 :root[tabsintitlebar][inFullscreen][leftWindowControls] #toolbar-menubar[autohide="false"] {


### PR DESCRIPTION
**Fix window controls overlapping menu bar when on left side**

See https://github.com/MrAlex94/Waterfox/pull/1353#issuecomment-573449402

**correct default for hidden `browser.tabs.drawInTitlebar`**

On Linux systems where `browser.tabs.drawInTitlebar` is not exposed in `about:config` by default, its default value is determined dynamically based on desktop environment.  This change aligns #1289 code with other code that checks this pref, fixing consistency issues with the enabled/disabled state of the preferences UI for Window Controls position.