### PR TITLE
[Current] Show title in menubar when Tab Bar position is different than default.

### DIFF
--- a/browser/base/content/browser.xul
+++ b/browser/base/content/browser.xul
@@ -709,6 +709,7 @@
 #include browser-menubar.inc
         </toolbaritem>
         <spacer flex="1" skipintoolbarset="true" ordinal="1000"/>
+        <hbox id="toolbar-menubar-pagetitle"></hbox>
 #include titlebar-items.inc.xul
 #include titlebar-fs-items.inc.xul
       </toolbar>

--- a/browser/base/content/tabbrowser.js
+++ b/browser/base/content/tabbrowser.js
@@ -1019,6 +1019,7 @@
 
     updateTitlebar() {
       document.title = this.getWindowTitleForBrowser(this.selectedBrowser);
+      windowRoot.ownerGlobal.document.querySelector("#toolbar-menubar-pagetitle").textContent = this.getWindowTitleForBrowser(this.selectedBrowser).replace(' - '+windowRoot.ownerGlobal.document.querySelector("window").getAttribute("titlemodifier"), '');
     },
 
     updateCurrentBrowser(aForceUpdate) {

--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -573,3 +573,20 @@
 :root[inFullscreen]:not([tabBarPosition="topAboveAB"]) #toolbar-menubar {
   visibility: visible;
 }
+
+:root[tabsintitlebar]:not([tabBarPosition="topAboveAB"]) #toolbar-menubar-pagetitle {
+  display: inherit;
+  margin-right: 30px;
+  margin-left: 30px;
+  align-items: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  -moz-box-ordinal-group: 1000;
+  -moz-box-flex: 1;
+  margin-top: 5px;
+}
+
+#toolbar-menubar-pagetitle {
+  display: none;
+}


### PR DESCRIPTION
In Vivaldi when native window is disabled and menubar is enabled, then title is show on top. It's also displayed on top when menubar is disabled or enabled and titlebar is disabled and Tab Bar is on other position than top.

In case of Waterfox Current I did little different,  I left Mozilla's behavior when Tab Bar is on default position and added title to top menubar only when Tab Bar is on another position.

![Screenshot_20200124_164108](https://user-images.githubusercontent.com/19818572/73081688-59407800-3ec8-11ea-9385-a2f7a2a10585.png)
