### PR TITLE
(Current) Fix ability to add add-ons via AMO (macOS).

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1406,7 +1406,7 @@ pref("privacy.firstparty.isolate.restrict_opener_access", true);
 pref("privacy.firstparty.isolate.block_post_message", false);
 
 // If true, DISABLES navigator.mozAddonManager entirely
-sticky_pref("privacy.resistFingerprinting.block_mozAddonManager", true);
+sticky_pref("privacy.resistFingerprinting.block_mozAddonManager", false);
 
 // We automatically decline canvas permission requests if they are not initiated
 // from user input. Just in case that breaks something, we allow the user to revert


### PR DESCRIPTION
Clean installs of Waterfox Current are not able to add add-ons via AMO if this is set to "true". Setting it to "false" fixes the issue.