### PR TITLE
(Current) Privacy: Delete temporary files on exit (macOS).

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -306,7 +306,7 @@ pref("browser.display.focus_ring_style", 1);
 
 pref("browser.helperApps.neverAsk.saveToDisk", "");
 pref("browser.helperApps.neverAsk.openFile", "");
-pref("browser.helperApps.deleteTempFileOnExit", false);
+pref("browser.helperApps.deleteTempFileOnExit", true);
 
 // xxxbsmedberg: where should prefs for the toolkit go?
 pref("browser.chrome.toolbar_tips",         true);


### PR DESCRIPTION
Align the behavior of Waterfox under macOS with that under Windows and Linux. See here:

https://bugzilla.mozilla.org/show_bug.cgi?id=238789