### PR TITLE
bypass failling stylo compile

### DIFF
--- a/.mozconfig
+++ b/.mozconfig
@@ -35,7 +35,7 @@ ac_add_options --target=x86_64-pc-linux-gnu
 ac_add_options --enable-pulseaudio
 ac_add_options --enable-alsa
 ac_add_options --enable-rust-simd # on x86 requires SSE2
-ac_add_options --enable-stylo=build
+ac_add_options --disable-stylo
 fi
 
 ac_add_options --enable-av1


### PR DESCRIPTION
15:26:50  5:14.19 error: failed to run custom build command for `style
   v0.0.1 (/home/ubuntu/servo/components/style)`
   15:26:50  5:14.19
   15:26:50  5:14.19 Caused by:
   15:26:50  5:14.19   process didn't exit successfully:
      `/home/ubuntu/objdir-classic/toolkit/library/release/build/style-37684f63e7929e6d/build-script-build`
      (exit code: 1)
        1

python2.7: can't open file 'servo/components/style/properties/build.py': [Errno 2] No such file or directory