### PR TITLE
[Classic] Bug 1601813 - Parse av01 codec when parsing Widevine manifests.

### DIFF
--- a/dom/media/gmp/GMPParent.cpp
+++ b/dom/media/gmp/GMPParent.cpp
@@ -800,6 +800,15 @@ GMPParent::ParseChromiumManifest(const nsAString& aJSON)
   nsTArray<nsCString> codecs;
   SplitAt(",", codecsString, codecs);
 
+  // Parse the codec strings in the manifest and map them to strings used
+  // internally by Gecko for capability recognition.
+  //
+  // Google's code to parse manifests can be used as a reference for strings
+  // the manifest may contain
+  // https://cs.chromium.org/chromium/src/chrome/common/media/cdm_manifest.cc?l=73&rcl=393e60bfc2299449db7ef374c0ef1c324716e562
+  //
+  // Gecko's internal strings can be found at
+  // https://searchfox.org/mozilla-central/rev/ea63a0888d406fae720cf24f4727d87569a8cab5/dom/media/eme/MediaKeySystemAccess.cpp#149-155
   for (const nsCString& chromiumCodec : codecs) {
     nsCString codec;
     if (chromiumCodec.EqualsASCII("vp8")) {
@@ -808,6 +817,8 @@ GMPParent::ParseChromiumManifest(const nsAString& aJSON)
       codec = NS_LITERAL_CSTRING("vp9");
     } else if (chromiumCodec.EqualsASCII("avc1")) {
       codec = NS_LITERAL_CSTRING("h264");
+    } else if (chromiumCodec.EqualsASCII("av01")) {
+      codec = NS_LITERAL_CSTRING("av1");
     } else {
       return GenericPromise::CreateAndReject(NS_ERROR_FAILURE, __func__);
     }


### PR DESCRIPTION
Seems that @MrAlex94 forgot about this. Without this, new Widevine will fail to load.