### PR TITLE
(Current) Privacy: Disable link prefetching, disable DNS prefetching.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -2183,8 +2183,11 @@ pref("network.dns.native-is-localhost", false);
 pref("network.dnsCacheExpirationGracePeriod", 60);
 
 // This preference can be used to turn off DNS prefetch.
-pref("network.dns.disablePrefetch", false);
+pref("network.dns.disablePrefetch", true);
 
+// This preference can be used to turn off DNS prefetch (HTTPS).
+pref("network.dns.disablePrefetchFromHTTPS", true)
+     
 // This preference controls whether .onion hostnames are
 // rejected before being given to DNS. RFC 7686
 pref("network.dns.blockDotOnion", true);
@@ -2216,7 +2219,7 @@ pref("network.ftp.idleConnectionTimeout", 300);
 
 // enables the prefetch service (i.e., prefetching of <link rel="next"> and
 // <link rel="prefetch"> URLs).
-pref("network.prefetch-next", true);
+pref("network.prefetch-next", false);
 // enables the preloading (i.e., preloading of <link rel="preload"> URLs).
 pref("network.preload", false);
 


### PR DESCRIPTION
See here ("Prefetching" section):
https://support.mozilla.org/en-US/kb/how-stop-firefox-making-automatic-connections

And here:
https://www.ghacks.net/2013/04/27/firefox-prefetching-what-you-need-to-know/

And most importantly, here:

https://www.usenix.org/legacy/events/leet10/tech/full_papers/Krishnan.pdf

Improves privacy by reducing speculative connections Waterfox might otherwise establish. Supposedly comes with a performance penalty, though I haven't noticed anything in this regard even on script-heavy websites. No website breakage whatsoever is to be expected here.