### PR TITLE
(Current) Privacy: Only send pings if send and receiving host match (…

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -293,7 +293,7 @@ pref("browser.enable_click_image_resizing", true);
 // See http://whatwg.org/specs/web-apps/current-work/#ping
 pref("browser.send_pings", false);
 pref("browser.send_pings.max_per_link", 1);           // limit the number of pings that are sent per link click
-pref("browser.send_pings.require_same_host", false);  // only send pings to the same host if this is true
+pref("browser.send_pings.require_same_host", true);  // only send pings to the same host if this is true
 
 pref("browser.display.use_focus_colors",    false);
 pref("browser.display.focus_background_color", "#117722");


### PR DESCRIPTION
…same website).

Reduces privacy fallout in case pings are getting enabled by the user, by default they are disabled (browser.send_pings is set to "false" by default). Should be safe to merge, no website breakage is expected.