### PR TITLE
(Current) Privacy: Enable tracking protection by default (Part 1).

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1561,7 +1561,6 @@ pref("browser.ping-centre.production.endpoint", "", locked);
 // Enable GMP support in the addon manager.
 pref("media.gmp-provider.enabled", true);
 
-#ifdef EARLY_BETA_OR_EARLIER
 // Enable blocking access to storage from tracking resources only in nightly
 // and early beta. By default the value is 0: BEHAVIOR_ACCEPT
 pref("network.cookie.cookieBehavior", 4 /* BEHAVIOR_REJECT_TRACKER */);
@@ -1569,7 +1568,6 @@ pref("network.cookie.cookieBehavior", 4 /* BEHAVIOR_REJECT_TRACKER */);
 pref("privacy.trackingprotection.fingerprinting.enabled", true);
 // Enable cryptomining blocking by default only in nightly and early beta.
 pref("privacy.trackingprotection.cryptomining.enabled", true);
-#endif
 
 pref("dom.storage_access.enabled", true);
 


### PR DESCRIPTION
Anti-cryptomining, anti-fingerprinting, anti-tracking-cookie protection enabled by default. Should be safe to enable, known cryptomining + fingerprinting scripts, as well as known tracking cookies are concerned. Tested on several major sites, like eBay, Amazon, Facebook, Twitter, YouTube, Google Search, Google Maps, Instagram etc. No breakage to report. Mozilla plans to enable these as well in the near future.