### PR TITLE
(Current) Privacy / Security: Get rid of MFS.

### DIFF
--- a/security/manager/ssl/security-prefs.js
+++ b/security/manager/ssl/security-prefs.js
@@ -53,7 +53,7 @@ pref("security.password_lifetime",       30);
 // and trust third party root certificates from the OS).
 // With any other value of the pref or on any other platform, this does nothing.
 // This preference takes precedence over "security.enterprise_roots.enabled".
-pref("security.family_safety.mode", 2);
+pref("security.family_safety.mode", 0);
 
 pref("security.enterprise_roots.enabled", true);
 


### PR DESCRIPTION
Get rid of Microsoft Family Safety, a local man in the middle proxy. This has security and privacy reasons. Can still be enabled if so desired. Align the behavior of Waterfox Current with Waterfox Classic for this pref.