### PR TITLE
(Current) Privacy: Get rid of SSL error telemetry.

### DIFF
--- a/security/manager/ssl/security-prefs.js
+++ b/security/manager/ssl/security-prefs.js
@@ -140,9 +140,9 @@ pref("security.webauth.webauthn_enable_usbtoken", false);
 pref("security.webauth.webauthn_enable_usbtoken", true);
 #endif
 
-pref("security.ssl.errorReporting.enabled", false);
-pref("security.ssl.errorReporting.url", "https://incoming.telemetry.mozilla.org/submit/sslreports/");
-pref("security.ssl.errorReporting.automatic", false);
+pref("security.ssl.errorReporting.enabled", false, locked);
+pref("security.ssl.errorReporting.url", "", locked);
+pref("security.ssl.errorReporting.automatic", false, locked);
 
 // Impose a maximum age on HPKP headers, to avoid sites getting permanently
 // blacking themselves out by setting a bad pin.  (60 days by default)


### PR DESCRIPTION
See header.