### PR TITLE
(Current) No longer hide / unhide the download button.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -370,7 +370,7 @@ pref("browser.download.panel.shown", false);
 
 // This controls whether the button is automatically shown/hidden depending
 // on whether there are downloads to show.
-pref("browser.download.autohideButton", true);
+pref("browser.download.autohideButton", false);
 
 #ifndef XP_MACOSX
 pref("browser.helperApps.deleteTempFileOnExit", true);


### PR DESCRIPTION
The download button appearing and disappearing all the time is most confusing, this pref makes the download button permanent by default. Can still be changed back by the user if so desired.