### PR TITLE
[Classic] Bug 1387912 - Add missing #include to dom/canvas/ImageBitmap.h.

### DIFF
--- a/dom/canvas/ImageBitmap.h
+++ b/dom/canvas/ImageBitmap.h
@@ -13,6 +13,7 @@
 #include "mozilla/gfx/Rect.h"
 #include "mozilla/Maybe.h"
 #include "mozilla/UniquePtr.h"
+#include "gfxTypes.h" // for gfxAlphaType
 #include "nsCycleCollectionParticipant.h"
 
 struct JSContext;


### PR DESCRIPTION
Build fails with more optimizations. This is fix for that problem.