### PR TITLE
(Classic) Privacy: No more information about the graphics driver for …

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4747,7 +4747,7 @@ pref("webgl.perf.spew-frame-allocs", true);
 
 pref("webgl.enable-webgl2", true);
 
-pref("webgl.enable-debug-renderer-info", true);
+pref("webgl.enable-debug-renderer-info", false);
 pref("webgl.renderer-string-override", "");
 pref("webgl.vendor-string-override", "");
 


### PR DESCRIPTION
…debugging purposes.

This reduces possible misuse for hardware fingerprinting. See here:
https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_debug_renderer_info

Various Firefox-related privacy guides recommend disabling this setting. No website breakage is expected here.