### PR TITLE
(Classic) Privacy: Enable tracking protection by default.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1389,7 +1389,7 @@ pref("privacy.donottrackheader.enabled",    false);
 // the popup will be called when the popup is dismissed.
 pref("privacy.permissionPrompts.showCloseButton", false);
 // Enforce tracking protection in all modes
-pref("privacy.trackingprotection.enabled",  false);
+pref("privacy.trackingprotection.enabled",  true);
 // Enforce tracking protection in Private Browsing mode
 pref("privacy.trackingprotection.pbmode.enabled",  true);
 // Annotate channels based on the tracking protection list in all modes


### PR DESCRIPTION
See header. Enables tracking protection, only blocks known tracking cookies. No website breakage is expected here, since Waterfox by default uses the normal blocklist instead of the strict one.