### PR TITLE
(Current) Privacy: Disable predictive service by default.

### DIFF
--- a/modules/libpref/init/StaticPrefList.h
+++ b/modules/libpref/init/StaticPrefList.h
@@ -2223,7 +2223,7 @@ VARCACHE_PREF(
 VARCACHE_PREF(
   "network.predictor.enabled",
    network_predictor_enabled,
-  bool, true
+  bool, false
 )
 
 // Allow CookieSettings to be unblocked for channels without a document.


### PR DESCRIPTION
See header. Most Firefox privacy guides recommend disabling this.