### PR TITLE
[Current] Use more appropriate application name for cmdline info.

### DIFF
--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -1448,9 +1448,13 @@ static void DumpHelp() {
 
 static inline void DumpVersion() {
   if (gAppData->vendor) {
-    printf("%s ", (const char*)gAppData->vendor);
+    nsCString name(gAppData->name);
+    nsCString vendor(gAppData->vendor);
+    if (name != vendor) {
+      printf("%s ", (const char*)gAppData->vendor);
+    }
   }
-  printf("%s ", (const char*)gAppData->name);
+  printf("%s ", MOZ_APP_DISPLAYNAME);
 
   // Use the displayed version
   // For example, for beta, we would display 42.0b2 instead of 42.0


### PR DESCRIPTION
Now should display `Waterfox Current` instead of `Waterfox Waterfox`. In case of, if will vendor change to for example Vendor1, then it will display `Vendor1 Waterfox Current`.