### PR TITLE
[Classic] Add user-agent override for Amazon Prime Video.

### DIFF
--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -42,5 +42,6 @@
   "westpac.com.au": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
   "gizmodo.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
   "zoho.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "att.tv": "Mozilla/5.0 (@OS_SLICE@) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
+  "att.tv": "Mozilla/5.0 (@OS_SLICE@) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
+  "primevideo.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0"
 }


### PR DESCRIPTION
On free videos as part of an action #stayathome, I got message that updating browser is required, of course user-agent override helps in that case.