### PR TITLE
(Classic) Enable Shutdown Decoder

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -456,11 +456,7 @@ pref("media.decoder-doctor.wmf-disabled-is-failure", false);
 pref("media.decoder-doctor.new-issue-endpoint", "https://webcompat.com/issues/new");
 
 // Whether to suspend decoding of videos in background tabs.
-#ifdef RELEASE_OR_BETA
-pref("media.suspend-bkgnd-video.enabled", false);
-#else
 pref("media.suspend-bkgnd-video.enabled", true);
-#endif
 // Delay, in ms, from time window goes to background to suspending
 // video decoders. Defaults to 10 seconds.
 pref("media.suspend-bkgnd-video.delay-ms", 10000);


### PR DESCRIPTION
### Enables the [Shutdown Decoder](https://wiki.mozilla.org/Firefox/Shutdown_Decoders) feature
**The Shutdown Decoder is a feature that was finalized and feature complete in Firefox 56 but wasn't enabled until Firefox 57. This pull requset will solve issue #1229**
​
Here is how the Feature is described in the Firefox 57 release notes:

> Video decoding is shut down when the tab playing the media is sent to the background or the video is not visible on the screen. Video resumes when the media tab is in the foreground and the player is visible on the screen. Audio will not be affected.