### PR TITLE
[Current] Bug 1611520 - Include <cstddef> in FunctionTypeTraits.h

### DIFF
--- a/mfbt/FunctionTypeTraits.h
+++ b/mfbt/FunctionTypeTraits.h
@@ -9,6 +9,7 @@
 #ifndef mozilla_FunctionTypeTraits_h
 #define mozilla_FunctionTypeTraits_h
 
+#include <cstddef> /* for size_t */
 #include <tuple>
 
 namespace mozilla {


### PR DESCRIPTION
Without this small fix, build fails on Fedora Rawhide with Clang 10 (`error: unknown type name 'size_t'; did you mean 'std::size_t'?`).