### PR TITLE
(Current) Privacy: Add privacy.resistFingerprinting.delegateCanvasProtection 

### DIFF
--- a/dom/canvas/CanvasUtils.cpp
+++ b/dom/canvas/CanvasUtils.cpp
@@ -138,6 +138,18 @@ bool IsImageExtractionAllowed(Document* aDocument, JSContext* aCx,
 
   // At this point, permission is unknown
   // (nsIPermissionManager::UNKNOWN_ACTION).
+  
+  // Check if the user has explicitly disabled all
+  // or delegated all other checks and fingerprinting resistence
+  // to an extension (or nothing) such as canvasblocker
+  bool isDelegateCanvasProtection =
+      StaticPrefs::
+          privacy_resistFingerprinting_delegateCanvasProtection() &&
+      !EventStateManager::IsHandlingUserInput();
+
+  if (isDelegateCanvasProtection) {
+    return true;
+  }
 
   // Check if the request is in response to user input
   bool isAutoBlockCanvas =

--- a/modules/libpref/init/StaticPrefList.h
+++ b/modules/libpref/init/StaticPrefList.h
@@ -2569,6 +2569,12 @@ VARCACHE_PREF(
 )
 
 VARCACHE_PREF(
+  "privacy.resistFingerprinting.delegateCanvasProtection",
+   privacy_resistFingerprinting_delegateCanvasProtection,
+  RelaxedAtomicBool, false
+)
+
+VARCACHE_PREF(
   "privacy.storagePrincipal.enabledForTrackers",
    privacy_storagePrincipal_enabledForTrackers,
   RelaxedAtomicBool, false

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1413,6 +1413,9 @@ sticky_pref("privacy.resistFingerprinting.block_mozAddonManager", false);
 // If you do set it, to work around some broken website, please file a bug with
 // information so we can understand why it is needed.
 pref("privacy.resistFingerprinting.autoDeclineNoUserInputCanvasPrompts", true);
+// In the event the end user wants to use RFP but wishes to fully enable the canvas
+// or delegate it's protection an extension, this option allows for it.
+pref("privacy.resistFingerprinting.delegateCanvasProtection", false);
 // The log level for browser console messages logged in RFPHelper.jsm
 // Change to 'All' and restart to see the messages
 pref("privacy.resistFingerprinting.jsmloglevel", "Warn");


### PR DESCRIPTION
Currently Waterfox and Firefox both break CanvasBlocker and other addons that seek to make canvas fingerprinting harder. While people debate over what is best for these situations, recent changes to RFP caused these extensions to no longer fulfill their primary purpose of randomizing the canvas fingerprint hashes.

This tweak adds a default false option of 

```privacy.resistFingerprinting.delegateCanvasProtection``` 

 which when enabled, stops checks of canvas permissions just before Waterfox would normally show or autodecline the request to read the canvas API.

This way, the other prior checks are still enforced, but should the end user, a privacy centric or power user, should desire, they can either disable the rest of the handling of canvas protection entirely (if no addon is configured) or more ideally, use CanvasBlocker to block, randomize, black/whitelist, or display prompts for canvas data extraction where necessary, all while retaining the other benefits that come from using RFP.

If this or something like it were added to Waterfox, I feel many many more users would switch to Waterfox, especially the ghacks user.js crowd and the various privacy communities that are around.
