### PR TITLE
[Classic] Fix WebAudio.

### DIFF
--- a/dom/media/webaudio/AudioBuffer.cpp
+++ b/dom/media/webaudio/AudioBuffer.cpp
@@ -274,6 +274,9 @@ AudioBuffer::CopyFromChannel(const Float32Array& aDestination, uint32_t aChannel
                              uint32_t aStartInChannel, ErrorResult& aRv)
 {
 
+  JS::AutoCheckCannotGC nogc;
+  aDestination.ComputeLengthAndData();
+
   uint32_t length = aDestination.Length();
   CheckedInt<uint32_t> end = aStartInChannel;
   end += length;
@@ -283,8 +286,6 @@ AudioBuffer::CopyFromChannel(const Float32Array& aDestination, uint32_t aChannel
     return;
   }
 
-  JS::AutoCheckCannotGC nogc;
-  uint32_t count = std::min(Length() - aStartInChannel, aDestination.Length());
   JSObject* channelArray = mJSChannels[aChannelNumber];
   const float* sourceData = nullptr;
   if (channelArray) {
@@ -315,6 +316,8 @@ AudioBuffer::CopyToChannel(JSContext* aJSContext, const Float32Array& aSource,
                            uint32_t aChannelNumber, uint32_t aStartInChannel,
                            ErrorResult& aRv)
 {
+  JS::AutoCheckCannotGC nogc;
+  aSource.ComputeLengthAndData();
 
   uint32_t length = aSource.Length();
   CheckedInt<uint32_t> end = aStartInChannel;
@@ -330,7 +333,6 @@ AudioBuffer::CopyToChannel(JSContext* aJSContext, const Float32Array& aSource,
     return;
   }
 
-  JS::AutoCheckCannotGC nogc;
   JSObject* channelArray = mJSChannels[aChannelNumber];
   if (JS_GetTypedArrayLength(channelArray) != mLength) {
     // The array's buffer was detached.
@@ -338,7 +340,6 @@ AudioBuffer::CopyToChannel(JSContext* aJSContext, const Float32Array& aSource,
     return;
   }
 
-  uint32_t count = std::min(Length() - aStartInChannel, aSource.Length());
   bool isShared = false;
   float* channelData = JS_GetFloat32ArrayData(channelArray, &isShared, nogc);
   // The channelData arrays should all have originated in


### PR DESCRIPTION
Seems that changes from https://github.com/MrAlex94/Waterfox/commit/b2af756c2b0e7a184629446adf885a6b717a1904 have caused WebAudio to stop working on some sites. Same problem as on UXP => https://github.com/MoonchildProductions/UXP/issues/1539.

That small change fixes this :smile:.