### PR TITLE
Fix linking by removing duplicate definitions

### DIFF
--- a/media/ffvpx/README_MOZILLA
+++ b/media/ffvpx/README_MOZILLA
@@ -31,7 +31,11 @@ $ grep -E ".*_(INDEV|OUTDEV|DECODER|ENCODER|DEMUXER|MUXER|PARSER|FILTER|HWACCEL|
 $ grep -E ".*_(INDEV|OUTDEV|DECODER|ENCODER|DEMUXER|MUXER|PARSER|FILTER|HWACCEL|PROTOCOL|ENCODERS|DECODERS|HWACCELS|INDEVS|OUTDEVS|FILTERS|DEMUXERS|MUXERS|PROTOCOLS|BSF) 0" config.asm > ~/Work/Mozilla/mozilla-central/media/ffvpx/defaults_disabled.asm
 
 All new decoders/muxers/encoders/... should be added in the list of dummy functions found in libavcodec/dummy_funcs.c
-otherwise linkage will fail on Windows. On other platforms they are optimised out and aren't necessary.
+otherwise linkage will fail on Windows. On other platforms they aren't necessary.
+(They may be optimised out, or may break the build when linking, e.g. with
+-fno-common, which is enabled for GCC 10
+<https://gcc.gnu.org/gcc-10/porting_to.html#common>. This is why the dummy
+functions are disabled except for Windows builds.)
 The GNU comm utility is a useful tool to compare and extract only the changes.
 
 To update the source tree, perform a diff on the files listed in FILES.

--- a/media/ffvpx/libavcodec/moz.build
+++ b/media/ffvpx/libavcodec/moz.build
@@ -20,7 +20,6 @@ SOURCES += [
     'bsf.c',
     'codec_desc.c',
     'decode.c',
-    'dummy_funcs.c',
     'flac.c',
     'flac_parser.c',
     'flacdata.c',
@@ -63,6 +62,11 @@ SOURCES += [
     'vp9recon.c',
     'xiph.c'
 ]
+# Dummy functions are required for windows NoOpt/PGO builds.
+if CONFIG['_MSC_VER']:
+    SOURCES += [
+        'dummy_funcs.c'
+    ]
 
 SYMBOLS_FILE = 'avcodec.symbols'
 NoVisibilityFlags()

--- a/media/ffvpx/libavutil/moz.build
+++ b/media/ffvpx/libavutil/moz.build
@@ -21,7 +21,6 @@ SOURCES += [
     'cpu.c',
     'crc.c',
     'dict.c',
-    'dummy_funcs.c',
     'error.c',
     'eval.c',
     'fifo.c',
@@ -50,6 +49,11 @@ SOURCES += [
     'timecode.c',
     'utils.c',
 ]
+# Dummy functions are required for windows NoOpt/PGO builds.
+if CONFIG['_MSC_VER']:
+    SOURCES += [
+        'dummy_funcs.c'
+    ]
 
 SYMBOLS_FILE =  'avutil.symbols'
 NoVisibilityFlags()


### PR DESCRIPTION
The linker does not merge tentatively defined objects which are placed
in the BSS section of object files. As the dummy definitions are
required for building on Windows, keep them for Windows builds. Disable
them when building for other platforms.

This allows builds with -fno-common (default for GCC 10) to succeed. See
<https://gcc.gnu.org/gcc-10/porting_to.html#common> for further details.

Fixes #1575.