### PR TITLE
[Current] Fix problems with overlay extensions.

### DIFF
--- a/browser/components/extensions/common/bindings/toolbar.xml
+++ b/browser/components/extensions/common/bindings/toolbar.xml
@@ -395,11 +395,7 @@
   </binding>
 
   <binding id="toolbar-menubar-autohide"
-#ifdef MOZ_SUITE
-           extends="chrome://communicator/content/bindings/toolbar.xml#toolbar">
-#else
            extends="chrome://browser/content/toolbar.xml#toolbar">
-#endif
     <implementation>
       <constructor>
         this._setInactive();
@@ -547,11 +543,7 @@
   </binding>
 
   <binding id="toolbarpaletteitem-palette"
-#ifdef MOZ_SUITE
-           extends="chrome://communicator/content/bindings/toolbar.xml#toolbarpaletteitem">
-#else
            extends="chrome://browser/content/toolbar.xml#toolbarpaletteitem">
-#endif
     <content>
       <xul:hbox class="toolbarpaletteitem-box" xbl:inherits="type,place">
         <children/>
@@ -561,11 +553,7 @@
   </binding>
 
   <binding id="toolbarpaletteitem-palette-wrapping-label"
-#ifdef MOZ_SUITE
-           extends="chrome://communicator/content/bindings/toolbar.xml#toolbarpaletteitem">
-#else
            extends="chrome://browser/content/toolbar.xml#toolbarpaletteitem">
-#endif
     <content>
       <xul:hbox class="toolbarpaletteitem-box" xbl:inherits="type,place">
         <children/>

--- a/browser/components/extensions/parent/ext-legacy.js
+++ b/browser/components/extensions/parent/ext-legacy.js
@@ -127,7 +127,7 @@ this.legacy = class extends ExtensionAPI {
     }
 
     // Add overlays to all existing windows.
-    let enumerator = Services.wm.getEnumerator("mail:3pane");
+    let enumerator = Services.wm.getEnumerator("navigator:browser");
     if (enumerator.hasMoreElements() && enumerator.getNext().document.readyState == "complete") {
       getAllWindows().forEach(w => Overlays.load(chromeManifest, w));
     }

--- a/toolkit/content/xul.css
+++ b/toolkit/content/xul.css
@@ -191,8 +191,12 @@ menulist {
 }
 
 /******* toolbar *******/
+toolbar {
+  -moz-binding: url("chrome://browser/content/toolbar.xml#toolbar");
+}
 
 toolbox {
+  -moz-binding: url("chrome://browser/content/toolbar.xml#toolbox");
   -moz-box-orient: vertical;
 }
 


### PR DESCRIPTION
I tried to convert some overlay extension to legacy webextension and I though that I did something wrong, but seems that bug was in browser's code, there is no `mail:3pane` in Waterfox, so overlays can't work.

Another broken thing are toolbar bindings. I fixed them and added to css 2 bindings, there are more bindings, but seems that some may break browser's layout (appmenu), so for now I only added which I need and seems that won't cause problems.