### PR TITLE
[Classic] Remove deprecated sysctl.h inclusion.

### DIFF
--- a/memory/mozjemalloc/mozjemalloc.cpp
+++ b/memory/mozjemalloc/mozjemalloc.cpp
@@ -208,9 +208,6 @@ typedef long ssize_t;
 #include <sys/param.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#if !defined(MOZ_MEMORY_SOLARIS) && !defined(MOZ_MEMORY_ANDROID)
-#include <sys/sysctl.h>
-#endif
 #include <sys/uio.h>
 
 #include <errno.h>


### PR DESCRIPTION
On Fedora Rawhide I got build error, because of that.
Anyway, seems that's not needed and even Moonchild removed that => https://github.com/MoonchildProductions/UXP/commit/fcc84d7b9ba2eac1c2687d401b3f3d619bb1de4c#diff-bdb53b93f350702da408d1d830f84b3c.