### PR TITLE
[Classic] Use CSD for toplevel window on Pop! OS.

### DIFF
--- a/widget/gtk/nsWindow.cpp
+++ b/widget/gtk/nsWindow.cpp
@@ -7019,6 +7019,9 @@ nsWindow::GetSystemCSDSupportLevel() {
         // GNOME Flashback (fallback)
         if (strstr(currentDesktop, "GNOME-Flashback:GNOME") != nullptr) {
             sCSDSupportLevel = CSD_SUPPORT_CLIENT;
+        // Pop Linux Bug 1629198
+        } else if (strstr(currentDesktop, "pop:GNOME") != nullptr) {
+            sCSDSupportLevel = CSD_SUPPORT_CLIENT;
         // gnome-shell
         } else if (strstr(currentDesktop, "GNOME") != nullptr) {
             sCSDSupportLevel = CSD_SUPPORT_SYSTEM;


### PR DESCRIPTION
Reported on https://www.reddit.com/r/waterfox/comments/guoi5x/how_to_remove_the_title_bar_in_waterfox_on_pop_os/. Same problem is also on Waterfox Current.