### PR TITLE
[Classic] Fix the wrong position when we calculate the position for position:absolute child

### DIFF
--- a/layout/generic/nsAbsoluteContainingBlock.cpp
+++ b/layout/generic/nsAbsoluteContainingBlock.cpp
@@ -697,8 +697,8 @@ nsAbsoluteContainingBlock::ReflowAbsoluteFrame(nsIFrame*                aDelegat
 
   // Get the border values
   WritingMode outerWM = aReflowInput.GetWritingMode();
-  const LogicalMargin border(outerWM,
-                             aReflowInput.mStyleBorder->GetComputedBorder());
+  const LogicalMargin border(outerWM, aDelegatingFrame->GetUsedBorder());
+
   LogicalMargin margin =
     kidReflowInput.ComputedLogicalMargin().ConvertTo(outerWM, wm);
 


### PR DESCRIPTION
You can see the problem on https://codepen.io/vr8088/pen/yLeBVbN.

> The table is set to "border-collapse: collapse"
> A child td has "position: relative" and a non-zero border width
> The td contains an element set to "position: absolute"
> 
> Results before PR: The element is positioned relative to the td plus a small offset in the x and y directions. The size of this offset seems to depend on the td's border width.
> 
> Results with PR: The element with "position: absolute" is positioned relative to the position of the td (= of the first not-static ancestor element).