### PR TITLE
[Current] Add image/webp to default navigation value of the Accept header

### DIFF
--- a/devtools/client/netmonitor/test/browser_net_copy_headers.js
+++ b/devtools/client/netmonitor/test/browser_net_copy_headers.js
@@ -40,7 +40,7 @@ add_task(async function() {
     `${method} ${SIMPLE_URL} ${httpVersion}`,
     "Host: example.com",
     "User-Agent: " + navigator.userAgent + "",
-    "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language: " + navigator.languages.join(",") + ";q=0.5",
     "Accept-Encoding: gzip, deflate",
     "Connection: keep-alive",

--- a/netwerk/protocol/http/nsHttpHandler.cpp
+++ b/netwerk/protocol/http/nsHttpHandler.cpp
@@ -118,7 +118,7 @@
   "network.tcp.tcp_fastopen_http_stalls_timeout"
 
 #define ACCEPT_HEADER_NAVIGATION \
-  "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
 #define ACCEPT_HEADER_IMAGE "image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"
 #define ACCEPT_HEADER_STYLE "text/css,*/*;q=0.1"
 #define ACCEPT_HEADER_ALL "*/*"

--- a/netwerk/test/mochitests/test_accept_header.html
+++ b/netwerk/test/mochitests/test_accept_header.html
@@ -26,7 +26,7 @@ function test_iframe() {
   let ifr = document.createElement("iframe");
   ifr.src = "test_accept_header.sjs?iframe";
   ifr.onload = () => {
-    test_last_request_and_continue("iframe", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+    test_last_request_and_continue("iframe", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
   };
   document.body.appendChild(ifr);
 }


### PR DESCRIPTION
Seems that some sites like `https://www.tabletowo.pl/` started requiring that to show some content.