### PR TITLE
(Current) Disable TLS1.3 0-RTT.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1869,7 +1869,7 @@ pref("network.http.altsvc.enabled", true);
 pref("network.http.altsvc.oe", true);
 
 // Turn on 0RTT data for TLS 1.3
-pref("security.tls.enable_0rtt_data", true);
+pref("security.tls.enable_0rtt_data", false);
 
 // the origin extension impacts h2 coalescing
 pref("network.http.originextension", true);


### PR DESCRIPTION
Follow Pale Moon's example here and disabling this by default. Can be used for tracking:

https://github.com/tlswg/tls13-spec/issues/1001