### PR TITLE
(Future) Display "Not Secure" on HTTP websites.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1405,8 +1405,8 @@ pref("security.insecure_connection_icon.pbmode.enabled", true);
 pref("security.secure_connection_icon_color_gray", true);
 
 // Show "Not Secure" text for http pages; disabled for now
-pref("security.insecure_connection_text.enabled", false);
-pref("security.insecure_connection_text.pbmode.enabled", false);
+pref("security.insecure_connection_text.enabled", true);
+pref("security.insecure_connection_text.pbmode.enabled", true);
 
 // 1 = allow MITM for certificate pinning checks.
 pref("security.cert_pinning.enforcement_level", 1);


### PR DESCRIPTION
See header. Align the behavior of future Waterfox versions with Waterfox Current in that regard.