### PR TITLE
(Classic) Increase session store interval to protect SSDs.

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -859,7 +859,7 @@ pref("browser.sessionstore.resume_from_crash", true);
 pref("browser.sessionstore.resume_session_once", false);
 
 // Minimal interval between two save operations in milliseconds (while the user is active).
-pref("browser.sessionstore.interval", 15000); // 15 seconds
+pref("browser.sessionstore.interval", 60000); // 1 minute
 
 // Minimal interval between two save operations in milliseconds (while the user is idle).
 pref("browser.sessionstore.interval.idle", 3600000); // 1h


### PR DESCRIPTION
Waterfox and Firefox write to the SSD quite heavily, thereby impacting its longevity:

https://www.servethehome.com/firefox-is-eating-your-ssd-here-is-how-to-fix-it/

This commit reduces the session recovery saves to a more reasonable once per minute (same as Pale Moon).