### PR TITLE
(Future) Render Mozilla ASAN telemetry impotent.

### DIFF
--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4567,7 +4567,7 @@ pref("dom.payments.defaults.saveAddress", true);
 pref("dom.payments.request.supportedRegions", "US,CA");
 
 #ifdef MOZ_ASAN_REPORTER
-  pref("asanreporter.apiurl", "https://anf1.fuzzing.mozilla.org/crashproxy/submit/");
+  pref("asanreporter.apiurl", "", locked);
   pref("asanreporter.clientid", "unknown");
   pref("toolkit.telemetry.overrideUpdateChannel", "nightly-asan");
 #endif


### PR DESCRIPTION
See header.