### PR TITLE
[Classic] Fix problems with building with Rust 1.45.

### DIFF
--- a/config/rules.mk
+++ b/config/rules.mk
@@ -867,7 +867,11 @@ cargo_rustc_flags = $(CARGO_RUSTCFLAGS)
 ifndef DEVELOPER_OPTIONS
 ifndef MOZ_DEBUG_RUST
 # Enable link-time optimization for release builds.
+# Pass -Clto for older versions of rust, and CARGO_PROFILE_RELEASE_LTO=true
+# for newer ones that support it. Combining the latter with -Clto works, so
+# set both everywhere.
 cargo_rustc_flags += -C lto
+export CARGO_PROFILE_RELEASE_LTO=true
 endif
 endif
 


### PR DESCRIPTION
This fixes #1663.