### PR TITLE
[Current] Fix sandbox problems on glib >=2.63

### DIFF
--- a/security/sandbox/linux/SandboxFilter.cpp
+++ b/security/sandbox/linux/SandboxFilter.cpp
@@ -1140,6 +1140,7 @@ class ContentSandboxPolicy : public SandboxPolicyCommon {
       case __NR_getpriority:
       case __NR_setpriority:
       case __NR_sched_getattr:
+      case __NR_sched_setattr:
       case __NR_sched_get_priority_min:
       case __NR_sched_get_priority_max:
       case __NR_sched_getscheduler:

--- a/security/sandbox/linux/SandboxFilter.cpp
+++ b/security/sandbox/linux/SandboxFilter.cpp
@@ -1139,6 +1139,7 @@ class ContentSandboxPolicy : public SandboxPolicyCommon {
 
       case __NR_getpriority:
       case __NR_setpriority:
+      case __NR_sched_getattr:
       case __NR_sched_get_priority_min:
       case __NR_sched_get_priority_max:
       case __NR_sched_getscheduler:


### PR DESCRIPTION
I see on console `Failed to set scheduler settings: Not implemented feature Sandbox: seccomp sandbox violation: pid 279380, tid 279463, syscall 314`, seems that's related with glib2 update. Anyway, looks like that's the fix for that.