### PR TITLE
[Classic] Add better fix for rustc 1.45+, show rustc info in about:buildconfig and fix about pages text color for GTK dark themes

### DIFF
--- a/build/moz.configure/rust.configure
+++ b/build/moz.configure/rust.configure
@@ -18,6 +18,7 @@ def rustc_info(rustc):
         version=Version(info.get('release', '0')),
         commit=info.get('commit-hash', 'unknown'),
     )
+set_config('RUSTC_VERSION', depends(rustc_info)(lambda info: str(info.version)))
 
 @depends_if(cargo)
 @checking('cargo version', lambda info: info.version)

--- a/config/rules.mk
+++ b/config/rules.mk
@@ -867,11 +867,12 @@ cargo_rustc_flags = $(CARGO_RUSTCFLAGS)
 ifndef DEVELOPER_OPTIONS
 ifndef MOZ_DEBUG_RUST
 # Enable link-time optimization for release builds.
-# Pass -Clto for older versions of rust, and CARGO_PROFILE_RELEASE_LTO=true
-# for newer ones that support it. Combining the latter with -Clto works, so
-# set both everywhere.
 cargo_rustc_flags += -C lto
-export CARGO_PROFILE_RELEASE_LTO=true
+# Versions of rust >= 1.45 need -Cembed-bitcode=yes for all crates when
+# using -Clto.
+ifeq (,$(filter 1.22.% 1.23.% 1.24.% 1.25.% 1.26.% 1.27.% 1.28.% 1.29.% 1.30.% 1.31.% 1.32.% 1.33.% 1.34.% 1.35.% 1.36.% 1.37.% 1.38.% 1.39.% 1.40.% 1.41.% 1.42.% 1.43.% 1.44.%,$(RUSTC_VERSION)))
+RUSTFLAGS += -Cembed-bitcode=yes
+endif
 endif
 endif
 

--- a/toolkit/content/buildconfig.html
+++ b/toolkit/content/buildconfig.html
@@ -54,6 +54,11 @@
       <td>@CXXFLAGS@ @CPPFLAGS@</td>
 #endif
     </tr>
+    <tr>
+      <td>@RUSTC@</td>
+      <td>@RUSTC_VERSION@</td>
+      <td>@RUSTFLAGS@</td>
+    </tr>
   </tbody>
 </table>
 <h2>Configure options</h2>

--- a/toolkit/content/moz.build
+++ b/toolkit/content/moz.build
@@ -6,10 +6,16 @@
 
 TEST_DIRS += ['tests']
 
-for var in ('target', 'MOZ_CONFIGURE_OPTIONS', 'CC', 'CC_VERSION', 'CXX'):
+for var in ('target', 'MOZ_CONFIGURE_OPTIONS', 'CC', 'CC_VERSION', 'CXX',
+            'RUSTC', 'RUSTC_VERSION'):
     DEFINES[var] = CONFIG[var]
 
 DEFINES['CFLAGS'] = CONFIG['OS_CFLAGS']
+
+rustflags = CONFIG['RUSTFLAGS']
+if not rustflags:
+    rustflags = []
+DEFINES['RUSTFLAGS'] = ' '.join(rustflags)
 
 if CONFIG['OS_TARGET'] == 'Android':
     DEFINES['ANDROID_PACKAGE_NAME'] = CONFIG['ANDROID_PACKAGE_NAME']

--- a/toolkit/themes/shared/about.css
+++ b/toolkit/themes/shared/about.css
@@ -4,6 +4,7 @@
 
 html {
   background: -moz-Dialog;
+  color: -moz-DialogText;
   line-height: 1.6em;
   padding: 0 1em;
   font: message-box;


### PR DESCRIPTION
In short, Mozilla discovered that setting `CARGO_PROFILE_RELEASE_LTO` has unwanted side effects. 