### PR TITLE
[Classic] Improve user-agent overrides

### DIFF
--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -47,5 +47,7 @@
   "meet.google.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
   "lexiacore5.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
   "steamcommunity.com": "Mozilla/5.0 (@OS_SLICE@) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
-  "codex.wordpress.org": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0"
+  "codex.wordpress.org": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
+  "answers.unrealengine.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
+  "cdn.polyfill.io": "Mozilla/5.0 (@OS_SLICE@ rv:56.0) Gecko/20100101 Firefox/56.0"
 }

--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -1,14 +1,3 @@
-#ifdef XP_UNIX
-#ifndef XP_MACOSX
-#define OS_SLICE X11; Linux x86_64;
-#else
-#define OS_SLICE Macintosh; Intel Mac OS X 10.13;
-#endif
-#else
-#define OS_SLICE Windows NT 10.0; Win64;
-#endif
-
-#filter substitution
 #filter slashslash
 // Everything after the first // on a line will be removed by the preproccesor.
 // Send these sites a custom user-agent. Bugs should be included with an entry.
@@ -16,38 +5,39 @@
 // "example.org": "regex_string#new_string"
 // "#" hash sign is the separator. If no hash sign, the full string is used as replacement.
 // NOTE: trailing commas are not valid JSON and will prevent the CDN from syncing.
+// %OS_SLICE% macro is resolved at runtime.
 {
-  "addons.mozilla.org": "Mozilla/5.0 (@OS_SLICE@ rv:57.0) Gecko/20100101 Firefox/57.0",
-  "studio.youtube.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/60.0",
-  "netflix.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "internet.xfinity.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "chase.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "web.whatsapp.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "spotify.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "amazon.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "amazon.co.uk": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "amazon.de": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "amazon.co.jp": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "cosmicshambles.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "volunteerlogin.org": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "polar.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "eon.tv": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "slack.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "wire.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "trello.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "tresorit.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "discord.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "hoopladigital.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "ucf.org.au": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "westpac.com.au": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "gizmodo.com": "Mozilla/5.0 (@OS_SLICE@ rv:68.0) Gecko/20100101 Firefox/68.0",
-  "zoho.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "att.tv": "Mozilla/5.0 (@OS_SLICE@) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
-  "primevideo.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "meet.google.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "lexiacore5.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "steamcommunity.com": "Mozilla/5.0 (@OS_SLICE@) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
-  "codex.wordpress.org": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "answers.unrealengine.com": "Mozilla/5.0 (@OS_SLICE@ rv:60.0) Gecko/20100101 Firefox/60.0",
-  "cdn.polyfill.io": "Mozilla/5.0 (@OS_SLICE@ rv:56.0) Gecko/20100101 Firefox/56.0"
+  "addons.mozilla.org": "Mozilla/5.0 (%OS_SLICE% rv:57.0) Gecko/20100101 Firefox/57.0",
+  "studio.youtube.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/60.0",
+  "netflix.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "internet.xfinity.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "chase.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "web.whatsapp.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "spotify.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "amazon.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "amazon.co.uk": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "amazon.de": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "amazon.co.jp": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "cosmicshambles.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "volunteerlogin.org": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "polar.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "eon.tv": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "slack.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "wire.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "trello.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "tresorit.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "discord.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "hoopladigital.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "ucf.org.au": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "westpac.com.au": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "gizmodo.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "zoho.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "att.tv": "Mozilla/5.0 (%OS_SLICE%) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
+  "primevideo.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "meet.google.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "lexiacore5.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "steamcommunity.com": "Mozilla/5.0 (%OS_SLICE%) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
+  "codex.wordpress.org": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "answers.unrealengine.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
+  "cdn.polyfill.io": "Mozilla/5.0 (%OS_SLICE% rv:56.0) Gecko/20100101 Firefox/56.0"
 }

--- a/netwerk/base/nsILoadGroup.idl
+++ b/netwerk/base/nsILoadGroup.idl
@@ -95,10 +95,4 @@ interface nsILoadGroup : nsIRequest
      * the docShell has created the default request.)
      */
     attribute nsLoadFlags defaultLoadFlags;
-
-    /**
-     * The cached user agent override created by UserAgentOverrides.jsm. Used
-     * for all sub-resource requests in the loadgroup.
-     */
-    attribute ACString userAgentOverrideCache;
 };

--- a/netwerk/base/nsLoadGroup.cpp
+++ b/netwerk/base/nsLoadGroup.cpp
@@ -811,20 +811,6 @@ nsLoadGroup::SetDefaultLoadFlags(uint32_t aFlags)
     return NS_OK;
 }
 
-NS_IMETHODIMP
-nsLoadGroup::GetUserAgentOverrideCache(nsACString & aUserAgentOverrideCache)
-{
-  aUserAgentOverrideCache = mUserAgentOverrideCache;
-  return NS_OK;
-}
-
-NS_IMETHODIMP
-nsLoadGroup::SetUserAgentOverrideCache(const nsACString & aUserAgentOverrideCache)
-{
-  mUserAgentOverrideCache = aUserAgentOverrideCache;
-  return NS_OK;
-}
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/netwerk/base/nsLoadGroup.h
+++ b/netwerk/base/nsLoadGroup.h
@@ -95,8 +95,6 @@ protected:
 
     /* For nsPILoadGroupInternal */
     uint32_t                        mTimedNonCachedRequestsUntilOnEndPageLoad;
-
-    nsCString                       mUserAgentOverrideCache;
 };
 
 } // namespace net

--- a/netwerk/protocol/http/UserAgentOverrides.jsm
+++ b/netwerk/protocol/http/UserAgentOverrides.jsm
@@ -4,6 +4,10 @@
 
 "use strict";
 
+#ifdef XP_WIN
+#define UA_SPARE_PLATFORM
+#endif
+
 this.EXPORTED_SYMBOLS = [ "UserAgentOverrides" ];
 
 const Ci = Components.interfaces;
@@ -14,6 +18,14 @@ Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import("resource://gre/modules/UserAgentUpdates.jsm");
 
 const PREF_OVERRIDES_ENABLED = "general.useragent.site_specific_overrides";
+const OSCPU = Cc["@mozilla.org/network/protocol;1?name=http"]
+                .getService(Ci.nsIHttpProtocolHandler)
+                .oscpu;
+#ifndef UA_SPARE_PLATFORM
+const PLATFORM = Cc["@mozilla.org/network/protocol;1?name=http"]
+                   .getService(Ci.nsIHttpProtocolHandler)
+                   .platform;
+#endif
 const MAX_OVERRIDE_FOR_HOST_CACHE_SIZE = 250;
 
 // lazy load nsHttpHandler to improve startup performance.
@@ -32,11 +44,19 @@ var gOverrideFunctions = [
   function (aHttpChannel) { return UserAgentOverrides.getOverrideForURI(aHttpChannel.URI); }
 ];
 var gBuiltUAs = new Map;
+var gOSSlice;
 
 this.UserAgentOverrides = {
   init: function uao_init() {
     if (gInitialized)
       return;
+
+    gOSSlice = OSCPU + ";";
+#ifndef UA_SPARE_PLATFORM
+    if (PLATFORM != "") {
+      gOSSlice = PLATFORM + "; " + gOSSlice;
+    }
+#endif
 
     gPrefBranch = Services.prefs.getBranch("general.useragent.override.");
     gPrefBranch.addObserver("", buildOverrides);
@@ -137,7 +157,7 @@ function getUserAgentFromOverride(override)
   if (search && replace) {
     userAgent = DEFAULT_UA.replace(new RegExp(search, "g"), replace);
   } else {
-    userAgent = override;
+    userAgent = override.replace(/%OS_SLICE%/g, gOSSlice);
   }
   gBuiltUAs.set(override, userAgent);
   return userAgent;

--- a/netwerk/protocol/http/UserAgentOverrides.jsm
+++ b/netwerk/protocol/http/UserAgentOverrides.jsm
@@ -44,9 +44,9 @@ this.UserAgentOverrides = {
     Services.prefs.addObserver(PREF_OVERRIDES_ENABLED, buildOverrides);
 
     try {
-      Services.obs.addObserver(HTTP_on_useragent_request, "http-on-useragent-request");
+      Services.obs.addObserver(HTTP_on_modify_request, "http-on-modify-request");
     } catch (x) {
-      // The http-on-useragent-request notification is disallowed in content processes.
+      // The http-on-modify-request notification is disallowed in content processes.
     }
 
     try {
@@ -123,7 +123,7 @@ this.UserAgentOverrides = {
 
     Services.prefs.removeObserver(PREF_OVERRIDES_ENABLED, buildOverrides);
 
-    Services.obs.removeObserver(HTTP_on_useragent_request, "http-on-useragent-request");
+    Services.obs.removeObserver(HTTP_on_modify_request, "http-on-modify-request");
   }
 };
 
@@ -163,7 +163,7 @@ function buildOverrides() {
   }
 }
 
-function HTTP_on_useragent_request(aSubject, aTopic, aData) {
+function HTTP_on_modify_request(aSubject, aTopic, aData) {
   let channel = aSubject.QueryInterface(Ci.nsIHttpChannel);
 
   for (let callback of gOverrideFunctions) {

--- a/netwerk/protocol/http/moz.build
+++ b/netwerk/protocol/http/moz.build
@@ -111,10 +111,9 @@ IPDL_SOURCES += [
     'PHttpChannel.ipdl',
 ]
 
-EXTRA_JS_MODULES += [
-    'UserAgentOverrides.jsm',
-    'UserAgentUpdates.jsm',
-]
+EXTRA_JS_MODULES += ['UserAgentUpdates.jsm']
+
+EXTRA_PP_JS_MODULES += ['UserAgentOverrides.jsm']
 
 include('/ipc/chromium/chromium-config.mozbuild')
 

--- a/netwerk/protocol/http/nsHttpChannel.h
+++ b/netwerk/protocol/http/nsHttpChannel.h
@@ -512,8 +512,6 @@ private:
 
     void MaybeWarnAboutAppCache();
 
-    void SetLoadGroupUserAgentOverride();
-
     void SetDoNotTrack();
 
     already_AddRefed<nsChannelClassifier> GetOrCreateChannelClassifier();

--- a/netwerk/protocol/http/nsHttpHandler.h
+++ b/netwerk/protocol/http/nsHttpHandler.h
@@ -319,12 +319,6 @@ public:
         NotifyObservers(chan, NS_HTTP_ON_STOP_REQUEST_TOPIC);
     }
 
-    // Called by the channel and cached in the loadGroup
-    void OnUserAgentRequest(nsIHttpChannel *chan)
-    {
-      NotifyObservers(chan, NS_HTTP_ON_USERAGENT_REQUEST_TOPIC);
-    }
-
     // Called by the channel before setting up the transaction
     void OnBeforeConnect(nsIHttpChannel *chan)
     {

--- a/netwerk/protocol/http/nsIHttpProtocolHandler.idl
+++ b/netwerk/protocol/http/nsIHttpProtocolHandler.idl
@@ -124,15 +124,6 @@ interface nsIHttpProtocolHandler : nsIProxiedProtocolHandler
 #define NS_HTTP_ON_EXAMINE_CACHED_RESPONSE_TOPIC "http-on-examine-cached-response"
 
 /**
- * Before an HTTP request corresponding to a channel with the LOAD_DOCUMENT_URI
- * flag is sent to the server, this observer topic is notified. The observer of
- * this topic can then choose to modify the user agent for this request before
- * the request is actually sent to the server. Additionally, the modified user
- * agent will be propagated to sub-resource requests from the same load group.
- */
-#define NS_HTTP_ON_USERAGENT_REQUEST_TOPIC "http-on-useragent-request"
-
-/**
  * This topic is notified for every http channel right after it called
  * OnStopRequest on its listener, regardless whether it was finished
  * successfully, failed or has been canceled.


### PR DESCRIPTION
There was a problem which prevented applying user-agent overrides to all requests. That fixes that by reverting bad changes done by Mozilla, as well as adds few user-agent overrides (`cdn.polyfill.io` is for https://www.reddit.com/r/waterfox/comments/hgudud/british_council_film_archive_videos_not_displayed/) and macro for providing more accurate OS information, which is resolved at runtime.