### PR TITLE
[Classic] Make <link disabled> work and disable http-equiv cookies draft. 

### DIFF
--- a/dom/base/nsContentSink.cpp
+++ b/dom/base/nsContentSink.cpp
@@ -309,7 +309,8 @@ nsContentSink::ProcessHeaderData(nsIAtom* aHeader, const nsAString& aValue,
 
   mDocument->SetHeaderData(aHeader, aValue);
 
-  if (aHeader == nsGkAtoms::setcookie) {
+  if (aHeader == nsGkAtoms::setcookie &&
+      Preferences::GetBool("dom.metaElement.setCookie.allowed", true)) {
     // Note: Necko already handles cookies set via the channel.  We can't just
     // call SetCookie on the channel because we want to do some security checks
     // here.

--- a/dom/base/nsContentSink.cpp
+++ b/dom/base/nsContentSink.cpp
@@ -794,13 +794,14 @@ nsContentSink::ProcessStyleLink(nsIContent* aElement,
   // If this is a fragment parser, we don't want to observe.
   // We don't support CORS for processing instructions
   bool isAlternate;
+  bool isExplicitlyEnabled;
   rv = mCSSLoader->LoadStyleLink(aElement, url, aTitle, aMedia, aAlternate,
                                  CORS_NONE, mDocument->GetReferrerPolicy(),
                                  integrity, mRunsToCompletion ? nullptr : this,
-                                 &isAlternate);
+                                 &isAlternate, &isExplicitlyEnabled);
   NS_ENSURE_SUCCESS(rv, rv);
 
-  if (!isAlternate && !mRunsToCompletion) {
+  if ((!isAlternate || isExplicitlyEnabled) && !mRunsToCompletion) {
     ++mPendingSheetCount;
     mScriptLoader->AddParserBlockingScriptExecutionBlocker();
   }

--- a/dom/base/nsStyleLinkElement.cpp
+++ b/dom/base/nsStyleLinkElement.cpp
@@ -507,8 +507,9 @@ nsStyleLinkElement::DoUpdateStyleSheet(nsIDocument* aOldDocument,
   nsAutoString title, type, media;
   bool isScoped;
   bool isAlternate;
+  bool isExplicitlyEnabled;
 
-  GetStyleSheetInfo(title, type, media, &isScoped, &isAlternate);
+  GetStyleSheetInfo(title, type, media, &isScoped, &isAlternate, &isExplicitlyEnabled);
 
   if (!type.LowerCaseEqualsLiteral("text/css")) {
     return NS_OK;
@@ -539,7 +540,8 @@ nsStyleLinkElement::DoUpdateStyleSheet(nsIDocument* aOldDocument,
     // Parse the style sheet.
     rv = doc->CSSLoader()->
       LoadInlineStyle(thisContent, text, mLineNumber, title, media,
-                      scopeElement, aObserver, &doneLoading, &isAlternate);
+                      scopeElement, aObserver, &doneLoading, &isAlternate,
+                      &isExplicitlyEnabled);
   }
   else {
     nsAutoString integrity;
@@ -566,13 +568,14 @@ nsStyleLinkElement::DoUpdateStyleSheet(nsIDocument* aOldDocument,
     rv = doc->CSSLoader()->
       LoadStyleLink(thisContent, clonedURI, title, media, isAlternate,
                     GetCORSMode(), referrerPolicy, integrity,
-                    aObserver, &isAlternate);
+                    aObserver, &isAlternate, &isExplicitlyEnabled);
     if (NS_FAILED(rv)) {
       // Don't propagate LoadStyleLink() errors further than this, since some
       // consumers (e.g. nsXMLContentSink) will completely abort on innocuous
       // things like a stylesheet load being blocked by the security system.
       doneLoading = true;
       isAlternate = false;
+      isExplicitlyEnabled = false;
       rv = NS_OK;
     }
   }

--- a/dom/base/nsStyleLinkElement.h
+++ b/dom/base/nsStyleLinkElement.h
@@ -98,7 +98,8 @@ protected:
                                  nsAString& aType,
                                  nsAString& aMedia,
                                  bool* aIsScoped,
-                                 bool* aIsAlternate) = 0;
+                                 bool* aIsAlternate,
+                                 bool* aIsExplicitlyEnabled) = 0;
 
   virtual mozilla::CORSMode GetCORSMode() const
   {

--- a/dom/html/HTMLLinkElement.h
+++ b/dom/html/HTMLLinkElement.h
@@ -84,8 +84,8 @@ public:
   virtual bool HasDeferredDNSPrefetchRequest() override;
 
   // WebIDL
-  bool Disabled();
-  void SetDisabled(bool aDisabled);
+  bool Disabled() const;
+  void SetDisabled(bool aDisabled, ErrorResult& aRv);
   // XPCOM GetHref is fine.
   void SetHref(const nsAString& aHref, ErrorResult& aRv)
   {
@@ -185,9 +185,16 @@ protected:
                                  nsAString& aType,
                                  nsAString& aMedia,
                                  bool* aIsScoped,
-                                 bool* aIsAlternate) override;
-protected:
+                                 bool* aIsAlternate,
+                                 bool* aIsExplicitlyEnabled) override;
   RefPtr<nsDOMTokenList> mRelList;
+
+  // The "explicitly enabled" flag. This flag is set whenever the `disabled`
+  // attribute is explicitly unset, and makes alternate stylesheets not be
+  // disabled by default anymore.
+  //
+  // See https://github.com/whatwg/html/issues/3840#issuecomment-481034206.
+  bool mExplicitlyEnabled = false;
 };
 
 } // namespace dom

--- a/dom/html/HTMLStyleElement.cpp
+++ b/dom/html/HTMLStyleElement.cpp
@@ -66,7 +66,7 @@ HTMLStyleElement::GetMozDisabled(bool* aDisabled)
 }
 
 bool
-HTMLStyleElement::Disabled()
+HTMLStyleElement::Disabled() const
 {
   StyleSheet* ss = GetSheet();
   return ss && ss->Disabled();
@@ -225,12 +225,14 @@ HTMLStyleElement::GetStyleSheetInfo(nsAString& aTitle,
                                     nsAString& aType,
                                     nsAString& aMedia,
                                     bool* aIsScoped,
-                                    bool* aIsAlternate)
+                                    bool* aIsAlternate,
+                                    bool* aIsExplicitlyEnabled)
 {
   aTitle.Truncate();
   aType.Truncate();
   aMedia.Truncate();
   *aIsAlternate = false;
+  *aIsExplicitlyEnabled = false;
 
   nsAutoString title;
   GetAttr(kNameSpaceID_None, nsGkAtoms::title, title);

--- a/dom/html/HTMLStyleElement.h
+++ b/dom/html/HTMLStyleElement.h
@@ -60,7 +60,7 @@ public:
   NS_DECL_NSIMUTATIONOBSERVER_CONTENTINSERTED
   NS_DECL_NSIMUTATIONOBSERVER_CONTENTREMOVED
 
-  bool Disabled();
+  bool Disabled() const;
   void SetDisabled(bool aDisabled);
   void SetMedia(const nsAString& aMedia, ErrorResult& aError)
   {
@@ -89,7 +89,8 @@ protected:
                          nsAString& aType,
                          nsAString& aMedia,
                          bool* aIsScoped,
-                         bool* aIsAlternate) override;
+                         bool* aIsAlternate,
+                         bool* aIsExplicitlyEnabled) override;
   /**
    * Common method to call from the various mutation observer methods.
    * aContent is a content node that's either the one that changed or its

--- a/dom/svg/SVGStyleElement.cpp
+++ b/dom/svg/SVGStyleElement.cpp
@@ -274,9 +274,11 @@ SVGStyleElement::GetStyleSheetInfo(nsAString& aTitle,
                                    nsAString& aType,
                                    nsAString& aMedia,
                                    bool* aIsScoped,
-                                   bool* aIsAlternate)
+                                   bool* aIsAlternate,
+                                   bool* aIsExplicitlyEnabled)
 {
   *aIsAlternate = false;
+  *aIsExplicitlyEnabled = false;
 
   nsAutoString title;
   GetAttr(kNameSpaceID_None, nsGkAtoms::title, title);

--- a/dom/svg/SVGStyleElement.h
+++ b/dom/svg/SVGStyleElement.h
@@ -96,7 +96,8 @@ protected:
                          nsAString& aType,
                          nsAString& aMedia,
                          bool* aIsScoped,
-                         bool* aIsAlternate) override;
+                         bool* aIsAlternate,
+                         bool* aIsExplicitlyEnabled) override;
   virtual CORSMode GetCORSMode() const override;
 
   /**

--- a/dom/webidl/HTMLLinkElement.webidl
+++ b/dom/webidl/HTMLLinkElement.webidl
@@ -14,7 +14,7 @@
 // http://www.whatwg.org/specs/web-apps/current-work/#the-link-element
 [HTMLConstructor]
 interface HTMLLinkElement : HTMLElement {
-  [Pure]
+  [CEReactions, SetterThrows, Pure]
            attribute boolean disabled;
   [CEReactions, SetterThrows, Pure]
            attribute DOMString href;

--- a/dom/xml/XMLStylesheetProcessingInstruction.cpp
+++ b/dom/xml/XMLStylesheetProcessingInstruction.cpp
@@ -131,13 +131,15 @@ XMLStylesheetProcessingInstruction::GetStyleSheetInfo(nsAString& aTitle,
                                                       nsAString& aType,
                                                       nsAString& aMedia,
                                                       bool* aIsScoped,
-                                                      bool* aIsAlternate)
+                                                      bool* aIsAlternate,
+                                                      bool* aIsExplicitlyEnabled)
 {
   aTitle.Truncate();
   aType.Truncate();
   aMedia.Truncate();
   *aIsScoped = false;
   *aIsAlternate = false;
+  *aIsExplicitlyEnabled = false;
 
   // xml-stylesheet PI is special only in prolog
   if (!nsContentUtils::InProlog(this)) {

--- a/dom/xml/XMLStylesheetProcessingInstruction.h
+++ b/dom/xml/XMLStylesheetProcessingInstruction.h
@@ -82,7 +82,8 @@ protected:
                          nsAString& aType,
                          nsAString& aMedia,
                          bool* aIsScoped,
-                         bool* aIsAlternate) override;
+                         bool* aIsAlternate,
+                         bool* aIsExplicitlyEnabled) override;
   virtual nsGenericDOMDataNode* CloneDataNode(mozilla::dom::NodeInfo *aNodeInfo,
                                               bool aCloneText) const override;
 };

--- a/extensions/cookie/test/file_domain_hierarchy_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     document.cookie = "can2=has2";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta3=tag3">
   <script type="text/javascript">
     document.cookie = "can3=has3";
 

--- a/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_hierarchy_inner_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta3=tag3

--- a/extensions/cookie/test/file_domain_inner.html
+++ b/extensions/cookie/test/file_domain_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_domain_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_domain_inner_inner.html
+++ b/extensions/cookie/test/file_domain_inner_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     document.cookie = "can2=has2";
 

--- a/extensions/cookie/test/file_domain_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_domain_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_image_inner.html
+++ b/extensions/cookie/test/file_image_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_image_inner.html^headers^
+++ b/extensions/cookie/test/file_image_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_image_inner_inner.html
+++ b/extensions/cookie/test/file_image_inner_inner.html
@@ -3,7 +3,6 @@
 <head>
   <link rel="stylesheet" type="text/css" media="all" href="http://example.org/tests/extensions/cookie/test/test1.css" />
   <link rel="stylesheet" type="text/css" media="all" href="http://example.com/tests/extensions/cookie/test/test2.css" />
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta2=tag2">
   <script type="text/javascript">
     function runTest() {
       document.cookie = "can2=has2";

--- a/extensions/cookie/test/file_image_inner_inner.html^headers^
+++ b/extensions/cookie/test/file_image_inner_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta2=tag2

--- a/extensions/cookie/test/file_loadflags_inner.html
+++ b/extensions/cookie/test/file_loadflags_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     function runTest() {
       document.cookie = "can=has";

--- a/extensions/cookie/test/file_loadflags_inner.html^headers^
+++ b/extensions/cookie/test/file_loadflags_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_localhost_inner.html
+++ b/extensions/cookie/test/file_localhost_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_localhost_inner.html^headers^
+++ b/extensions/cookie/test/file_localhost_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_loopback_inner.html
+++ b/extensions/cookie/test/file_loopback_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_loopback_inner.html^headers^
+++ b/extensions/cookie/test/file_loopback_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/file_subdomain_inner.html
+++ b/extensions/cookie/test/file_subdomain_inner.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-  <META HTTP-EQUIV="Set-Cookie" CONTENT="meta=tag">
   <script type="text/javascript">
     document.cookie = "can=has";
 

--- a/extensions/cookie/test/file_subdomain_inner.html^headers^
+++ b/extensions/cookie/test/file_subdomain_inner.html^headers^
@@ -1,0 +1,1 @@
+Set-Cookie: meta=tag

--- a/extensions/cookie/test/mochitest.ini
+++ b/extensions/cookie/test/mochitest.ini
@@ -6,16 +6,27 @@ support-files =
   damonbowling.jpg^headers^
   file_chromecommon.js
   file_domain_hierarchy_inner.html
+  file_domain_hierarchy_inner.html^headers^
   file_domain_hierarchy_inner_inner.html
+  file_domain_hierarchy_inner_inner.html^headers^
   file_domain_hierarchy_inner_inner_inner.html
+  file_domain_hierarchy_inner_inner_inner.html^headers^
   file_domain_inner.html
+  file_domain_inner.html^headers^
   file_domain_inner_inner.html
+  file_domain_inner_inner.html^headers^
   file_image_inner.html
+  file_image_inner.html^headers^
   file_image_inner_inner.html
+  file_image_inner_inner.html^headers^
   file_loadflags_inner.html
+  file_loadflags_inner.html^headers^
   file_localhost_inner.html
+  file_localhost_inner.html^headers^
   file_loopback_inner.html
+  file_loopback_inner.html^headers^
   file_subdomain_inner.html
+  file_subdomain_inner.html^headers^
   file_testcommon.js
   file_testloadflags.js
   file_testloadflags_chromescript.js

--- a/extensions/cookie/test/test_same_base_domain.html
+++ b/extensions/cookie/test/test_same_base_domain.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_domain_inner.html', 5, 2)">
+<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_domain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_2.html
+++ b/extensions/cookie/test/test_same_base_domain_2.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_3.html
+++ b/extensions/cookie/test/test_same_base_domain_3.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_same_base_domain_5.html
+++ b/extensions/cookie/test/test_same_base_domain_5.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://sub1.test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 5, 2)">
+<body onload="setupTest('http://sub1.test1.example.org/tests/extensions/cookie/test/file_subdomain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/extensions/cookie/test/test_samedomain.html
+++ b/extensions/cookie/test/test_samedomain.html
@@ -5,7 +5,7 @@
   <script type="text/javascript" src="/tests/SimpleTest/SimpleTest.js"></script>        
   <link rel="stylesheet" type="text/css" href="/tests/SimpleTest/test.css" />
 </head>
-<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_domain_inner.html', 5, 2)">
+<body onload="setupTest('http://example.org/tests/extensions/cookie/test/file_domain_inner.html', 4, 2)">
 <p id="display"></p>
 <pre id="test">
 <script class="testbody" type="text/javascript" src="file_testcommon.js">

--- a/layout/style/Loader.h
+++ b/layout/style/Loader.h
@@ -234,6 +234,8 @@ public:
    * @param [out] aCompleted whether parsing of the sheet completed.
    * @param [out] aIsAlternate whether the stylesheet ended up being an
    *        alternate sheet.
+   * @param [out] aIsExplicitlyEnabled whether the stylesheet was explicitly
+   *        enabled by having the disabled attribute removed.
    */
   nsresult LoadInlineStyle(nsIContent* aElement,
                            const nsAString& aBuffer,
@@ -243,7 +245,8 @@ public:
                            mozilla::dom::Element* aScopeElement,
                            nsICSSLoaderObserver* aObserver,
                            bool* aCompleted,
-                           bool* aIsAlternate);
+                           bool* aIsAlternate,
+                           bool* aIsExplicitlyEnabled);
 
   /**
    * Load a linked (document) stylesheet.  If a successful result is returned,
@@ -264,6 +267,8 @@ public:
    * @param [out] aIsAlternate whether the stylesheet actually ended up beinga
    *        an alternate sheet.  Note that this need not match
    *        aHasAlternateRel.
+   * @param [out] aIsExplicitlyEnabled whether the stylesheet was explicitly
+   *        enabled by having the disabled attribute removed.
    */
   nsresult LoadStyleLink(nsIContent* aElement,
                          nsIURI* aURL,
@@ -274,7 +279,8 @@ public:
                          ReferrerPolicy aReferrerPolicy,
                          const nsAString& aIntegrity,
                          nsICSSLoaderObserver* aObserver,
-                         bool* aIsAlternate);
+                         bool* aIsAlternate,
+                         bool* aIsExplicitlyEnabled);
 
   /**
    * Load a child (@import-ed) style sheet.  In addition to loading the sheet,
@@ -508,7 +514,8 @@ private:
                     const nsAString& aMediaString,
                     dom::MediaList* aMediaList,
                     dom::Element* aScopeElement,
-                    bool aIsAlternate);
+                    bool aIsAlternate,
+                    bool isExplicitlyEnabled);
 
   nsresult InsertSheetInDoc(StyleSheet* aSheet,
                             nsIContent* aLinkingContent,

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1279,6 +1279,14 @@ pref("dom.storage.testing", false);
 
 pref("dom.send_after_paint_to_content", false);
 
+// Whether the disabled attribute in HTMLLinkElement disables the sheet loading
+// altogether, or forwards to the inner stylesheet method without attribute
+// reflection.
+//
+// Historical behavior is the second, the first is being discussed at:
+// https://github.com/whatwg/html/issues/3840
+pref("dom.link.disabled_attribute.enabled", true);
+
 // Timeout clamp in ms for timeouts we clamp
 pref("dom.min_timeout_value", 4);
 // And for background windows

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5545,6 +5545,9 @@ pref("intl.allow-insecure-text-input", false);
 // Enable meta-viewport support in remote APZ-enabled frames.
 pref("dom.meta-viewport.enabled", false);
 
+// Disable <meta http-equiv=set-cookie> support. See BMO 1457503.
+pref("dom.metaElement.setCookie.allowed", false);
+
 // Search service settings
 pref("browser.search.log", false);
 pref("browser.search.update", true);


### PR DESCRIPTION
All tests should pass:

https://wpt.live/css/cssom/HTMLLinkElement-disabled-001.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-002.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-003.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-004.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-005.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-006.html
https://wpt.live/css/cssom/HTMLLinkElement-disabled-007.html
http://w3c-test.org/cookies/meta-blocked.html
