### PR TITLE
[Classic] Check for correct system-sqlite version

### DIFF
--- a/old-configure.in
+++ b/old-configure.in
@@ -66,7 +66,7 @@ W32API_VERSION=3.14
 GCONF_VERSION=1.2.1
 STARTUP_NOTIFICATION_VERSION=0.8
 DBUS_VERSION=0.60
-SQLITE_VERSION=3.30.1
+SQLITE_VERSION=3.33.0
 
 dnl Set various checks
 dnl ========================================================


### PR DESCRIPTION
Otherwise we can build against too old system-sqlite which then breaks
startup of waterfox showing an error message that sqlite has not been
updated.