### PR TITLE
[Classic] Set SPOOFED_OSCPU as Windows 10 (like in Current).

### DIFF
--- a/browser/components/resistfingerprinting/test/browser/browser_navigator.js
+++ b/browser/components/resistfingerprinting/test/browser/browser_navigator.js
@@ -13,7 +13,7 @@ var spoofedUserAgent;
 const SPOOFED_APPNAME        = "Netscape";
 const SPOOFED_APPVERSION     = "5.0 (Windows)";
 const SPOOFED_PLATFORM       = "Win64";
-const SPOOFED_OSCPU          = "Windows NT 6.1; Win64; x64";
+const SPOOFED_OSCPU          = "Windows NT 10.0; Win64; x64";
 const SPOOFED_BUILDID        = "20100101";
 const SPOOFED_HW_CONCURRENCY = 2;
 

--- a/toolkit/components/resistfingerprinting/nsRFPService.h
+++ b/toolkit/components/resistfingerprinting/nsRFPService.h
@@ -15,7 +15,7 @@
 // are returned when 'privacy.resistFingerprinting' is true.
 #define SPOOFED_APPNAME    "Netscape"
 #define SPOOFED_APPVERSION "5.0 (Windows)"
-#define SPOOFED_OSCPU      "Windows NT 6.1; Win64; x64"
+#define SPOOFED_OSCPU      "Windows NT 10.0; Win64; x64"
 #define SPOOFED_PLATFORM   "Win64"
 
 #define LEGACY_BUILD_ID    "20100101"


### PR DESCRIPTION
Cosmetic fix for "resist fingerprinting" mode.