### PR TITLE
[Classic] Don't prevent switching back to Reload for top level about: loads

### DIFF
--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -5027,8 +5027,7 @@ var CombinedStopReload = {
   },
 
   switchToReload(aRequest, aWebProgress) {
-    if (!this._initialized || !this._shouldSwitch(aRequest) ||
-        !this.reload.hasAttribute("displaystop"))
+    if (!this._initialized || !this.reload.hasAttribute("displaystop"))
       return;
 
     let shouldAnimate = AppConstants.MOZ_PHOTON_ANIMATIONS &&


### PR DESCRIPTION
https://github.com/gorhill/uBlock-for-firefox-legacy/issues/260