### PR TITLE
CVE-2020-15999

### DIFF
--- a/modules/freetype2/ChangeLog
+++ b/modules/freetype2/ChangeLog
@@ -1,3 +1,11 @@
+2020-10-19  Werner Lemberg  <wl@gnu.org>
+
+	[sfnt] Fix heap buffer overflow (#59308).
+
+	This is CVE-2020-15999.
+
+	* src/sfnt/pngshim.c (Load_SBit_Png): Test bitmap size earlier.
+
 2018-05-01  Werner Lemberg  <wl@gnu.org>
 
 	* Version 2.9.1 released.

--- a/modules/freetype2/src/sfnt/pngshim.c
+++ b/modules/freetype2/src/sfnt/pngshim.c
@@ -327,6 +327,13 @@
 
     if ( populate_map_and_metrics )
     {
+      /* reject too large bitmaps similarly to the rasterizer */
+      if ( imgHeight > 0x7FFF || imgWidth > 0x7FFF )
+      {
+        error = FT_THROW( Array_Too_Large );
+        goto DestroyExit;
+      }
+
       metrics->width  = (FT_UShort)imgWidth;
       metrics->height = (FT_UShort)imgHeight;
 
@@ -335,13 +342,6 @@
       map->pixel_mode = FT_PIXEL_MODE_BGRA;
       map->pitch      = (int)( map->width * 4 );
       map->num_grays  = 256;
-
-      /* reject too large bitmaps similarly to the rasterizer */
-      if ( map->rows > 0x7FFF || map->width > 0x7FFF )
-      {
-        error = FT_THROW( Array_Too_Large );
-        goto DestroyExit;
-      }
     }
 
     /* convert palette/gray image to rgb */


### PR DESCRIPTION
Details: https://savannah.nongnu.org/bugs/?59308.
The patch is suitable for both versions.