### PR TITLE
[Classic] Add user-agent override for Yahoo.

### DIFF
--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -40,5 +40,6 @@
   "codex.wordpress.org": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
   "answers.unrealengine.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
   "cdn.polyfill.io": "Mozilla/5.0 (%OS_SLICE% rv:56.0) Gecko/20100101 Firefox/56.0",
-  "swedbank.se": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0"
+  "swedbank.se": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "yahoo.com": "Mozilla/5.0 (%OS_SLICE% rv:99.9) Gecko/20100101 Firefox/99.9"
 }


### PR DESCRIPTION
As reported on https://www.reddit.com/r/waterfox/comments/j7s5qa/yahoo_mail_seems_to_run_only_in_basic_mode/.