### PR TITLE
feat: add Startpage search engine choice screen

### DIFF
--- a/browser/components/newtab/aboutwelcome/content/aboutwelcome.bundle.js
+++ b/browser/components/newtab/aboutwelcome/content/aboutwelcome.bundle.js
@@ -1049,8 +1049,29 @@ const DEFAULT_WELCOME_CONTENT = {
       }
     }
   }, {
-    id: "AW_DEFAULT",
+    id: "AW_STARTPAGE",
     order: 3,
+    content: {
+      zap: true,
+      title: "Add privacy to your search",
+      subtitle: "For the most private experience, setting your search engine to Startpage is recommended",
+      primary_button: {
+        label: "Set Private Search",
+        action: {
+          type: "SET_DEFAULT_SEARCH_ENGINE",
+          navigate: true
+        }
+      },
+      secondary_button: {
+        label: "Continue with default",
+        action: {
+          navigate: true
+        }
+      }
+    }
+  }, {
+    id: "AW_DEFAULT",
+    order: 4,
     content: {
       zap: true,
       title: "Best as Default",
@@ -1073,7 +1094,7 @@ const DEFAULT_WELCOME_CONTENT = {
     }
   }, {
     id: "AW_PRIVACY",
-    order: 4,
+    order: 5,
     content: {
       title: "Automatic Privacy",
       subtitle: "Waterfox automatically blocks trackers and malware, and keeps companies from secretly following you around. When you see the shield while browsing, Waterfox is protecting you.",

--- a/browser/components/newtab/aboutwelcome/content/aboutwelcome.bundle.js
+++ b/browser/components/newtab/aboutwelcome/content/aboutwelcome.bundle.js
@@ -1049,7 +1049,7 @@ const DEFAULT_WELCOME_CONTENT = {
       }
     }
   }, {
-    id: "AW_STARTPAGE",
+    id: "AW_DEFAULT",
     order: 3,
     content: {
       zap: true,

--- a/browser/components/newtab/content-src/lib/aboutwelcome-utils.js
+++ b/browser/components/newtab/content-src/lib/aboutwelcome-utils.js
@@ -188,16 +188,40 @@ export const DEFAULT_WELCOME_CONTENT = {
       },
     },
     {
-      id: "AW_DEFAULT",
+      id: "AW_STARTPAGE",
       order: 3,
       content: {
         zap: true,
-		title: "Best as Default",
-        subtitle: "Set Waterfox as your default web browser to get the best user experience.",
+        title: "Add privacy to your search",
+        subtitle:
+          "For the most private experience, setting your search engine to Startpage is recommended",
+        primary_button: {
+          label: "Set Private Search",
+          action: {
+            type: "SET_DEFAULT_SEARCH_ENGINE",
+            navigate: true,
+          },
+        },
+        secondary_button: {
+          label: "Continue with default",
+          action: {
+            navigate: true,
+          },
+        },
+      },
+    },
+    {
+      id: "AW_DEFAULT",
+      order: 4,
+      content: {
+        zap: true,
+        title: "Best as Default",
+        subtitle:
+          "Set Waterfox as your default web browser to get the best user experience.",
         primary_button: {
           label: "Make default...",
           action: {
-			  type: "SET_DEFAULT_BROWSER",
+            type: "SET_DEFAULT_BROWSER",
             navigate: true,
           },
         },
@@ -208,29 +232,32 @@ export const DEFAULT_WELCOME_CONTENT = {
           action: {
             navigate: true,
           },
-	    },
+        },
       },
     },
-	{
-	id: "AW_PRIVACY",
-	order: 4,
-	content: {
-	  title: "Automatic Privacy",
-	  subtitle: "Waterfox automatically blocks trackers and malware, and keeps companies from secretly following you around. When you see the shield while browsing, Waterfox is protecting you.",
-	  tiles: {
-	    type: "video",
-	    media_type: "privacy",
-	    source: {
-	      default : "resource://activity-stream/data/content/assets/privacy-onboarding.webm",
-	      dark : "resource://activity-stream/data/content/assets/privacy-onboarding-dark.webm"
-	    }
-	  },
-	  primary_button: {
-	    label: "Start Browsing",
-	    action: {
-	      navigate: true
-	      },
-	    },
+    {
+      id: "AW_PRIVACY",
+      order: 5,
+      content: {
+        title: "Automatic Privacy",
+        subtitle:
+          "Waterfox automatically blocks trackers and malware, and keeps companies from secretly following you around. When you see the shield while browsing, Waterfox is protecting you.",
+        tiles: {
+          type: "video",
+          media_type: "privacy",
+          source: {
+            default:
+              "resource://activity-stream/data/content/assets/privacy-onboarding.webm",
+            dark:
+              "resource://activity-stream/data/content/assets/privacy-onboarding-dark.webm",
+          },
+        },
+        primary_button: {
+          label: "Start Browsing",
+          action: {
+            navigate: true,
+          },
+        },
       },
     },
   ],

--- a/browser/components/newtab/content-src/lib/aboutwelcome-utils.js
+++ b/browser/components/newtab/content-src/lib/aboutwelcome-utils.js
@@ -188,7 +188,7 @@ export const DEFAULT_WELCOME_CONTENT = {
       },
     },
     {
-      id: "AW_STARTPAGE",
+      id: "AW_DEFAULT",
       order: 3,
       content: {
         zap: true,

--- a/toolkit/components/messaging-system/lib/SpecialMessageActions.jsm
+++ b/toolkit/components/messaging-system/lib/SpecialMessageActions.jsm
@@ -6,6 +6,7 @@
 const EXPORTED_SYMBOLS = ["SpecialMessageActions"];
 
 const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
 const { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );
@@ -80,7 +81,7 @@ const SpecialMessageActions = {
       Cu.reportError(e);
     }
   },
-  
+
   setAsDefault() {
     let claimAllTypes = true;
     let setAsDefaultError = false;
@@ -211,7 +212,12 @@ const SpecialMessageActions = {
         ]);
         break;
       case "SET_DEFAULT_BROWSER":
-		this.setAsDefault();
+        this.setAsDefault();
+        break;
+      case "SET_DEFAULT_SEARCH_ENGINE":
+        const sp = Services.search.getEngineByName("Startpage");
+        Services.search.setDefault(sp);
+        Services.search.setDefaultPrivate(sp);
         break;
       case "CANCEL":
         // A no-op used by CFRs that minimizes the notification but does not


### PR DESCRIPTION
Adds a screen to prompt the user to set Startpage.com as their default search engine on the first boot up.
<img width="1675" alt="Screen Shot 2020-11-02 at 3 10 57 PM" src="https://user-images.githubusercontent.com/614910/98148545-cd5d7280-1e81-11eb-9779-0a801921e7c4.png">
