### PR TITLE
[G3]  Fix text color of text on notification about default browser.

### DIFF
--- a/browser/themes/shared/abyss/userChrome.css
+++ b/browser/themes/shared/abyss/userChrome.css
@@ -552,7 +552,6 @@ panel#editBookmarkPanel button.expander-up {
   notification > hbox > button {
     border-radius: var(--wfx-border-radius) !important;
     border: 1px solid rgba(0,0,0,.3) !important;
-    color: black !important;
     background: rgba(255,255,255,1) !important;
     box-shadow: none !important;
   }

--- a/browser/themes/shared/floe/userChrome.css
+++ b/browser/themes/shared/floe/userChrome.css
@@ -574,7 +574,6 @@ panel#editBookmarkPanel button.expander-up {
   notification > hbox > button {
     border-radius: var(--wfx-border-radius) !important;
     border: 1px solid rgba(0,0,0,.3) !important;
-    color: black !important;
     background: rgba(255,255,255,1) !important;
     box-shadow: none !important;
   }


### PR DESCRIPTION
![2020-11-28_13-51](https://user-images.githubusercontent.com/19818572/100516012-02a76880-3181-11eb-9d07-428a96a30b02.png)

As you can see on Linux text on buttons on notification bar is not visible. This fixes that by removing forced value for color.
Probably this should be checked on Mac and Windows too.

