### PR TITLE
[G3] Hide information about browser for Android and iOS.

### DIFF
--- a/browser/themes/shared/preferences/preferences.inc.css
+++ b/browser/themes/shared/preferences/preferences.inc.css
@@ -796,6 +796,7 @@ dialog > .sync-engines-list + hbox {
 
 .fxaMobilePromo {
   margin-top: 2px !important;
+  display: none !important;
 }
 
 .androidIcon,


### PR DESCRIPTION
There is no Waterfox for Android and iOS currently and links are broken, so rather that should be hidden or removed.