### PR TITLE
[G3] Fix id of langpacks

### DIFF
--- a/browser/locales/Makefile.in
+++ b/browser/locales/Makefile.in
@@ -21,9 +21,9 @@ PWD := $(CURDIR)
 ZIP_IN ?= $(ABS_DIST)/$(PACKAGE)
 
 ifdef MOZ_DEV_EDITION
-MOZ_LANGPACK_EID=langpack-$(AB_CD)@l10n.waterfox.net.xpi
+MOZ_LANGPACK_EID=langpack-$(AB_CD)@l10n.waterfox.net
 else
-MOZ_LANGPACK_EID=langpack-$(AB_CD)@l10n.waterfox.net.xpi
+MOZ_LANGPACK_EID=langpack-$(AB_CD)@l10n.waterfox.net
 endif
 # For Nightly, we know where to get the builds from to do local repacks
 ifdef NIGHTLY_BUILD


### PR DESCRIPTION
As I described on https://www.reddit.com/r/waterfox/comments/kh2ran/waterfox_g302_broke_several_things_i_stopped/gglvoe2/?utm_source=reddit&utm_medium=web2x&context=3, wrong id prevented automatic activation of langpack when is set to detect OS language.