### PR TITLE
[G3] Show/hide statusbar settings depending on choices.

### DIFF
--- a/browser/components/preferences/main.js
+++ b/browser/components/preferences/main.js
@@ -814,7 +814,25 @@ var gMainPane = {
     );
     Preferences.addSyncFromPrefListener(
       document.getElementById("statusBarRadioGroup"),
-      () => toggleStatusBar()
+      () => {
+        toggleStatusBar();
+
+        const showButtonsRange = document.getElementById("showButtonsRange");
+        const showLinks = document.getElementById("showLinks");
+        const statusbarMode = Services.prefs.getIntPref("browser.statusbar.mode");
+
+        if (statusbarMode == 0) {
+          showLinks.disabled = true;
+        } else {
+          showLinks.disabled = "";
+        }
+
+        if (statusbarMode == 2) {
+          showButtonsRange.disabled = "";
+        } else {
+          showButtonsRange.disabled = true;
+        }
+      }
     );
     Preferences.addSyncFromPrefListener(
       document.getElementById("showButtonsRange"),


### PR DESCRIPTION
For example, when there is status overlay, then option „use buttons in range controls" shouldn't be active, cuz that option applies only to status bar.