### PR TITLE
[Classic] Add missing #include.

### DIFF
--- a/gfx/2d/BaseRect.h
+++ b/gfx/2d/BaseRect.h
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <ostream>
 
 #include "mozilla/Assertions.h"
@@ -381,18 +382,18 @@ struct BaseRect {
     width = XMost() - aX;
     x = aX;
   }
-  void SetRightEdge(T aXMost) { 
+  void SetRightEdge(T aXMost) {
     MOZ_ASSERT(aXMost >= x);
-    width = aXMost - x; 
+    width = aXMost - x;
   }
   void SetTopEdge(T aY) {
     MOZ_ASSERT(aY <= YMost());
     height = YMost() - aY;
     y = aY;
   }
-  void SetBottomEdge(T aYMost) { 
+  void SetBottomEdge(T aYMost) {
     MOZ_ASSERT(aYMost >= y);
-    height = aYMost - y; 
+    height = aYMost - y;
   }
   void Swap() {
     std::swap(x, y);

--- a/toolkit/components/telemetry/ProcessedStack.cpp
+++ b/toolkit/components/telemetry/ProcessedStack.cpp
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include <limits>
 #include "ProcessedStack.h"
 #if defined(MOZ_GECKO_PROFILER)
 #include "shared-libraries.h"


### PR DESCRIPTION
When compiling on Fedora Rawhide, there are errors `error: no member named 'numeric_limits' in namespace 'std'`. This fixes that.