### PR TITLE
Issue #1839: Browser quits with "Minimum OS version requirement not m…

### DIFF
--- a/toolkit/xre/nsNativeAppSupportCocoa.mm
+++ b/toolkit/xre/nsNativeAppSupportCocoa.mm
@@ -71,7 +71,7 @@ NS_IMETHODIMP nsNativeAppSupportCocoa::Start(bool* _retval) {
   // alert here.  But the alert's message and buttons would require custom
   // localization.  So (for now at least) we just log an English message
   // to the console before quitting.
-  if (major < 10 || (major == 10 && minor < 12)) {
+  if (major < 10 || (major == 10 && minor < 10)) {
     NSLog(@"Minimum OS version requirement not met!");
     return NS_OK;
   }


### PR DESCRIPTION
This should fix G3 builds failing to run on 10.10 and 10.11 even though the system requirements say 10.10. Assuming this code was brought in directly from Firefox which requires a minimum of 10.12. 