### PR TITLE
[G3] ensure distribution channels set correctly

### DIFF
--- a/browser/components/BrowserGlue.jsm
+++ b/browser/components/BrowserGlue.jsm
@@ -3831,6 +3831,8 @@ BrowserGlue.prototype = {
       for (const [key, value] of Object.entries(attrData)) {
         // if PTAG we only want to set the ptag pref
         if (key == "PTAG") {Services.prefs.setCharPref("browser.search.ptag", value); continue;}
+        // if mtm_source we want to set the distribution source pref & attribution data
+        if (key == "mtm_source") {Services.prefs.setCharPref("distribution.source", value)}
         // only add to postSigningData if this hasn't been called previously
         attributionStr += `&${key}=${value}`
       };

--- a/toolkit/modules/UpdateUtils.jsm
+++ b/toolkit/modules/UpdateUtils.jsm
@@ -96,7 +96,7 @@ var UpdateUtils = {
    */
   async formatUpdateURL(url) {
     const locale = await this.getLocale();
-
+    let defaultSearch = await Services.search.getDefault();
     return url
       .replace(/%(\w+)%/g, (match, name) => {
         switch (name) {
@@ -121,9 +121,15 @@ var UpdateUtils = {
           case "SYSTEM_CAPABILITIES":
             return getSystemCapabilities();
           case "DISTRIBUTION":
-            return getDistributionPrefValue(PREF_APP_DISTRIBUTION);
+            if (Services.prefs.getCharPref("browser.search.ptag", "")) {
+              return getDistributionPrefValue(PREF_APP_DISTRIBUTION) == "default" ? Services.prefs.getCharPref("distribution.source", "wfx") : getDistributionPrefValue(PREF_APP_DISTRIBUTION);
+            } else {
+              return getDistributionPrefValue(PREF_APP_DISTRIBUTION);
+            }
+            // return getDistributionPrefValue(PREF_APP_DISTRIBUTION);
           case "DISTRIBUTION_VERSION":
-            return getDistributionPrefValue(PREF_APP_DISTRIBUTION_VERSION);
+            return (getDistributionPrefValue(PREF_APP_DISTRIBUTION_VERSION) == "default" && defaultSearch.name == "Bing") ? Services.prefs.getCharPref("browser.search.ptag", "default") : getDistributionPrefValue(PREF_APP_DISTRIBUTION_VERSION);
+            // return getDistributionPrefValue(PREF_APP_DISTRIBUTION_VERSION);
         }
         return match;
       })


### PR DESCRIPTION
This makes sure that we can feed separate distribution specific updaters hopefully preventing issues such as when only one search engine was permitted