### PR TITLE
[Classic] Add few useful user-agent overrides.

### DIFF
--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -42,5 +42,8 @@
   "answers.unrealengine.com": "Mozilla/5.0 (%OS_SLICE% rv:60.0) Gecko/20100101 Firefox/60.0",
   "cdn.polyfill.io": "Mozilla/5.0 (%OS_SLICE% rv:56.0) Gecko/20100101 Firefox/56.0",
   "swedbank.se": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
-  "yahoo.com": "Mozilla/5.0 (%OS_SLICE% rv:99.9) Gecko/20100101 Firefox/99.9"
+  "yahoo.com": "Mozilla/5.0 (%OS_SLICE% rv:99.9) Gecko/20100101 Firefox/99.9",
+  "sakugabooru.com": "Mozilla/5.0 (%OS_SLICE% rv:99.0) Gecko/20100101 Firefox/99.0",
+  "securityboulevard.com": "Mozilla/5.0 (%OS_SLICE% rv:99.0) Gecko/20100101 Firefox/99.0",
+  "kb.vmware.com": "Mozilla/5.0 (%OS_SLICE% Trident/7.0; rv:11.0) like Gecko"
 }


### PR DESCRIPTION
Some websites are blocking access, cuz they are checking browser version and because WF Clasic is based on FF 56, they are assuming that it's insecure. So we need to tell them that our browser is super-secure, by telling them that's Firefox 99 :rofl: 

https://www.reddit.com/r/waterfox/comments/mkgovt/error_1020_in_with_waterfox/

I also added override for VMWare, cuz apparently they made site looking great in IE 11, but for Firefox they require `window.event` support. However site sometimes still has problems with viewing (css), but at least articles are readable.

It's workaround for #1774.