### PR TITLE
[Classic] Update user-agent override for Netflix

### DIFF
--- a/browser/app/ua-update.json.in
+++ b/browser/app/ua-update.json.in
@@ -9,7 +9,7 @@
 {
   "addons.mozilla.org": "Mozilla/5.0 (%OS_SLICE% rv:57.0) Gecko/20100101 Firefox/57.0",
   "studio.youtube.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/60.0",
-  "netflix.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",
+  "netflix.com": "Mozilla/5.0 (%OS_SLICE% rv:78.0) Gecko/20100101 Firefox/78.0",
   "internet.xfinity.com": "Mozilla/5.0 (%OS_SLICE% rv:78.0) Gecko/20100101 Firefox/78.0",
   "xfinity.com": "Mozilla/5.0 (%OS_SLICE% rv:78.0) Gecko/20100101 Firefox/78.0",
   "chase.com": "Mozilla/5.0 (%OS_SLICE% rv:68.0) Gecko/20100101 Firefox/68.0",


### PR DESCRIPTION
See https://help.netflix.com/en/node/23742#. Netflix requires FF 78 now.