### PR TITLE
[Classic] Make <menuitem> pref-controlled and disable by default

### DIFF
--- a/dom/html/HTMLMenuElement.cpp
+++ b/dom/html/HTMLMenuElement.cpp
@@ -116,7 +116,8 @@ HTMLMenuElement::AfterSetAttr(int32_t aNameSpaceID, nsIAtom* aName,
                               const nsAttrValue* aValue,
                               const nsAttrValue* aOldValue, bool aNotify)
 {
-  if (aNameSpaceID == kNameSpaceID_None && aName == nsGkAtoms::type) {
+  if (aNameSpaceID == kNameSpaceID_None && aName == nsGkAtoms::type &&
+      Preferences::GetBool("dom.menuitem.enabled")) {
     if (aValue) {
       mType = aValue->GetEnumValue();
     } else {
@@ -134,7 +135,8 @@ HTMLMenuElement::ParseAttribute(int32_t aNamespaceID,
                                 const nsAString& aValue,
                                 nsAttrValue& aResult)
 {
-  if (aNamespaceID == kNameSpaceID_None && aAttribute == nsGkAtoms::type) {
+  if (aNamespaceID == kNameSpaceID_None && aAttribute == nsGkAtoms::type &&
+      Preferences::GetBool("dom.menuitem.enabled")) {
     return aResult.ParseEnumValue(aValue, kMenuTypeTable, false,
                                   kMenuDefaultType);
   }

--- a/dom/html/HTMLMenuItemElement.cpp
+++ b/dom/html/HTMLMenuItemElement.cpp
@@ -8,12 +8,21 @@
 
 #include "mozilla/BasicEvents.h"
 #include "mozilla/EventDispatcher.h"
+#include "mozilla/Preferences.h"
 #include "mozilla/dom/HTMLMenuItemElementBinding.h"
+#include "mozilla/dom/HTMLUnknownElement.h"
 #include "nsAttrValueInlines.h"
 #include "nsContentUtils.h"
 
-
-NS_IMPL_NS_NEW_HTML_ELEMENT_CHECK_PARSER(MenuItem)
+nsGenericHTMLElement*
+NS_NewHTMLMenuItemElement(already_AddRefed<mozilla::dom::NodeInfo>&& aNodeInfo,
+                          mozilla::dom::FromParser aFromParser) {
+  if (mozilla::Preferences::GetBool("dom.menuitem.enabled")) {
+    return new mozilla::dom::HTMLMenuItemElement(aNodeInfo, aFromParser);
+  } else {
+    return new mozilla::dom::HTMLUnknownElement(aNodeInfo);
+  }
+}
 
 namespace mozilla {
 namespace dom {

--- a/dom/html/test/browser_content_contextmenu_userinput.js
+++ b/dom/html/test/browser_content_contextmenu_userinput.js
@@ -4,6 +4,9 @@ const kPage = "http://example.org/browser/" +
               "dom/html/test/file_content_contextmenu.html";
 
 add_task(async function() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["dom.menuitem.enabled", true]],
+  });
   await BrowserTestUtils.withNewTab({
     gBrowser,
     url: kPage

--- a/dom/html/test/mochitest.ini
+++ b/dom/html/test/mochitest.ini
@@ -1,4 +1,6 @@
 [DEFAULT]
+prefs = 
+  dom.menuitem.enabled=true # only for test_bug617528.html
 support-files =
   347174transform.xsl
   347174transformable.xml

--- a/dom/tests/mochitest/general/test_interfaces.js
+++ b/dom/tests/mochitest/general/test_interfaces.js
@@ -479,8 +479,6 @@ var interfaceNamesInGlobalScope =
 // IMPORTANT: Do not change this list without review from a DOM peer!
     "HTMLMenuElement",
 // IMPORTANT: Do not change this list without review from a DOM peer!
-    "HTMLMenuItemElement",
-// IMPORTANT: Do not change this list without review from a DOM peer!
     "HTMLMetaElement",
 // IMPORTANT: Do not change this list without review from a DOM peer!
     "HTMLMeterElement",

--- a/dom/tests/mochitest/webcomponents/htmlconstructor_builtin_tests.js
+++ b/dom/tests/mochitest/webcomponents/htmlconstructor_builtin_tests.js
@@ -72,7 +72,6 @@
   ['mark', ''],
   ['marquee', 'Div'],
   ['menu', 'Menu'],
-  ['menuitem', 'MenuItem'],
   ['meta', 'Meta'],
   ['meter', 'Meter'],
   ['nav', ''],

--- a/dom/webidl/EventHandler.webidl
+++ b/dom/webidl/EventHandler.webidl
@@ -80,6 +80,7 @@ interface GlobalEventHandlers {
            attribute EventHandler onseeked;
            attribute EventHandler onseeking;
            attribute EventHandler onselect;
+           [Pref="dom.menuitem.enabled"]
            attribute EventHandler onshow;
            //(Not implemented)attribute EventHandler onsort;
            attribute EventHandler onstalled;

--- a/dom/webidl/HTMLElement.webidl
+++ b/dom/webidl/HTMLElement.webidl
@@ -50,10 +50,8 @@ interface HTMLElement : Element {
            attribute DOMString contentEditable;
   [Pure]
   readonly attribute boolean isContentEditable;
-  [Pure]
+  [Pure, Pref="dom.menuitem.enabled"]
   readonly attribute HTMLMenuElement? contextMenu;
-  //[SetterThrows]
-  //         attribute HTMLMenuElement? contextMenu;
   [CEReactions, SetterThrows, Pure]
            attribute boolean spellcheck;
 

--- a/dom/webidl/HTMLMenuElement.webidl
+++ b/dom/webidl/HTMLMenuElement.webidl
@@ -17,9 +17,9 @@ interface MenuBuilder;
 // http://www.whatwg.org/specs/web-apps/current-work/#the-menu-element
 [HTMLConstructor]
 interface HTMLMenuElement : HTMLElement {
-           [CEReactions, SetterThrows]
+           [CEReactions, SetterThrows, Pref="dom.menuitem.enabled"]
            attribute DOMString type;
-           [CEReactions, SetterThrows]
+           [CEReactions, SetterThrows, Pref="dom.menuitem.enabled"]
            attribute DOMString label;
 };
 

--- a/dom/webidl/HTMLMenuItemElement.webidl
+++ b/dom/webidl/HTMLMenuItemElement.webidl
@@ -12,7 +12,7 @@
  */
 
 // http://www.whatwg.org/specs/web-apps/current-work/#the-menuitem-element
-[HTMLConstructor]
+[HTMLConstructor, Pref="dom.menuitem.enabled"]
 interface HTMLMenuItemElement : HTMLElement {
            [CEReactions, SetterThrows]
            attribute DOMString type;

--- a/layout/style/res/html.css
+++ b/layout/style/res/html.css
@@ -577,8 +577,10 @@ ul, menu, dir {
   padding-inline-start: 40px;
 }
 
-menu[type="context"] {
-  display: none !important;
+@supports -moz-bool-pref("dom.menuitem.enabled") {
+  menu[type="context"] {
+    display: none !important;
+  }
 }
 
 ol {

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -5351,6 +5351,9 @@ pref("dom.forms.inputmode", true);
 // Enable mapped array buffer by default.
 pref("dom.mapped_arraybuffer.enabled", true);
 
+// Whether <menuitem> is a thing or not.
+pref("dom.menuitem.enabled", false);
+
 // The tables used for Safebrowsing phishing and malware checks.
 pref("urlclassifier.malwareTable", "goog-malware-shavar,goog-unwanted-shavar,test-malware-simple,test-unwanted-simple");
 


### PR DESCRIPTION
> This HTML tag adds items to the content context menu and was only ever supported by Mozilla browsers and for reasons discussed over the years it could be abused for evil but is otherwise never used outside of an older incarnation of MDN its self.