### PR TITLE
[Classic] Preserve newlines in textarea placeholders.

### DIFF
--- a/dom/html/nsTextEditorState.cpp
+++ b/dom/html/nsTextEditorState.cpp
@@ -2838,7 +2838,11 @@ nsTextEditorState::UpdatePlaceholderText(bool aNotify)
 
   nsCOMPtr<nsIContent> content = do_QueryInterface(mTextCtrlElement);
   content->GetAttr(kNameSpaceID_None, nsGkAtoms::placeholder, placeholderValue);
-  nsContentUtils::RemoveNewlines(placeholderValue);
+  if (mTextCtrlElement->IsTextArea()) { // <textarea>s preserve newlines...
+    nsContentUtils::PlatformToDOMLineBreaks(placeholderValue);
+  } else { // ...<input>s don't
+    nsContentUtils::RemoveNewlines(placeholderValue);
+  }
   NS_ASSERTION(mPlaceholderDiv->GetFirstChild(), "placeholder div has no child");
   mPlaceholderDiv->GetFirstChild()->SetText(placeholderValue, aNotify);
 }

--- a/layout/forms/nsTextControlFrame.cpp
+++ b/layout/forms/nsTextControlFrame.cpp
@@ -337,11 +337,7 @@ nsTextControlFrame::CreateAnonymousContent(nsTArray<ContentInfo>& aElements)
   nsAutoString placeholderTxt;
   mContent->GetAttr(kNameSpaceID_None, nsGkAtoms::placeholder,
                     placeholderTxt);
-  if (IsTextArea()) { // <textarea>s preserve newlines...
-    nsContentUtils::PlatformToDOMLineBreaks(placeholderTxt);
-  } else { // ...<input>s don't
-    nsContentUtils::RemoveNewlines(placeholderTxt);
-  }
+  nsContentUtils::RemoveNewlines(placeholderTxt);
   mUsePlaceholder = !placeholderTxt.IsEmpty();
 
   // Create the placeholder anonymous content if needed.


### PR DESCRIPTION
There was a fix for new lines in textarea placeholders, but Mozilla moved few things in https://bugzilla.mozilla.org/show_bug.cgi?id=1401706, so it wasn't working properly.
There were 2 choices: apply [BMO 1401706](https://bugzilla.mozilla.org/show_bug.cgi?id=1401706) or move that code to proper place. I chose second solution, cuz it was less work and 1401706 is about fixing Servo crash.

Test => http://kwan.perix.co.uk/mozilla/ta-ph-cr.html