### PR TITLE
[Classic] Implement missing calculation support for stroke-dashoffset.

### DIFF
--- a/dom/svg/SVGContentUtils.cpp
+++ b/dom/svg/SVGContentUtils.cpp
@@ -831,6 +831,14 @@ SVGContentUtils::CoordToFloat(nsSVGElement *aContent,
     SVGSVGElement* ctx = aContent->GetCtx();
     return ctx ? aCoord.GetPercentValue() * ctx->GetLength(SVGContentUtils::XY) : 0.0f;
   }
+  case eStyleUnit_Calc: {
+    MOZ_ASSERT(aCoord.GetCalcValue(), "Invalid calc value");
+    nsStyleCoord::Calc* calc = aCoord.GetCalcValue();
+    SVGSVGElement* ctx = aContent->GetCtx();
+    float len = nsPresContext::AppUnitsToFloatCSSPixels(calc->mLength);
+    return ctx ? len + calc->mPercent * ctx->GetLength(SVGContentUtils::XY)
+               : len;
+  }
   default:
     return 0.0f;
   }

--- a/layout/style/StyleAnimationValue.cpp
+++ b/layout/style/StyleAnimationValue.cpp
@@ -70,11 +70,15 @@ GetCommonUnit(nsCSSPropertyID aProperty,
               StyleAnimationValue::Unit aSecondUnit)
 {
   if (aFirstUnit != aSecondUnit) {
+    bool numberAsPixel =
+      nsCSSProps::PropHasFlags(aProperty, CSS_PROPERTY_NUMBERS_ARE_PIXELS);
     if (nsCSSProps::PropHasFlags(aProperty, CSS_PROPERTY_STORES_CALC) &&
-        (aFirstUnit == StyleAnimationValue::eUnit_Coord ||
+        ((aFirstUnit == StyleAnimationValue::eUnit_Float && numberAsPixel) ||
+         aFirstUnit == StyleAnimationValue::eUnit_Coord ||
          aFirstUnit == StyleAnimationValue::eUnit_Percent ||
          aFirstUnit == StyleAnimationValue::eUnit_Calc) &&
-        (aSecondUnit == StyleAnimationValue::eUnit_Coord ||
+        ((aSecondUnit == StyleAnimationValue::eUnit_Float && numberAsPixel) ||
+         aSecondUnit == StyleAnimationValue::eUnit_Coord ||
          aSecondUnit == StyleAnimationValue::eUnit_Percent ||
          aSecondUnit == StyleAnimationValue::eUnit_Calc)) {
       // We can use calc() as the common unit.
@@ -406,6 +410,12 @@ ExtractCalcValue(const StyleAnimationValue& aValue)
     result.mLength = 0.0f;
     result.mPercent = aValue.GetPercentValue();
     result.mHasPercent = true;
+    return result;
+  }
+  if (aValue.GetUnit() == StyleAnimationValue::eUnit_Float) {
+    result.mLength = aValue.GetFloatValue();
+    result.mPercent = 0.0f;
+    result.mHasPercent = false;
     return result;
   }
   MOZ_ASSERT(aValue.GetUnit() == StyleAnimationValue::eUnit_Calc,

--- a/layout/style/nsCSSPropList.h
+++ b/layout/style/nsCSSPropList.h
@@ -3862,7 +3862,7 @@ CSS_PROP_SVG(
     CSS_PROPERTY_PARSE_VALUE |
         CSS_PROPERTY_NUMBERS_ARE_PIXELS,
     "",
-    VARIANT_HLPN | VARIANT_OPENTYPE_SVG_KEYWORD,
+    VARIANT_HLPN | VARIANT_OPENTYPE_SVG_KEYWORD | VARIANT_CALC,
     kStrokeContextValueKTable,
     offsetof(nsStyleSVG, mStrokeDashoffset),
     eStyleAnimType_Coord)

--- a/layout/style/nsCSSPropList.h
+++ b/layout/style/nsCSSPropList.h
@@ -3860,7 +3860,8 @@ CSS_PROP_SVG(
     stroke_dashoffset,
     StrokeDashoffset,
     CSS_PROPERTY_PARSE_VALUE |
-        CSS_PROPERTY_NUMBERS_ARE_PIXELS,
+        CSS_PROPERTY_NUMBERS_ARE_PIXELS |
+        CSS_PROPERTY_STORES_CALC,
     "",
     VARIANT_HLPN | VARIANT_OPENTYPE_SVG_KEYWORD | VARIANT_CALC,
     kStrokeContextValueKTable,


### PR DESCRIPTION
It's based on Moonchild's work and few things modified a little to match current code state in Classic.

Tests:
https://jsfiddle.net/7hf615oe/
https://codepen.io/tellaho/pen/PPRjbj/