### PR TITLE
[Classic] Fix issues with css appearance

### DIFF
--- a/widget/gtk/WidgetStyleCache.cpp
+++ b/widget/gtk/WidgetStyleCache.cpp
@@ -755,9 +755,6 @@ CreateHeaderBarButtons()
 static GtkWidget*
 CreateWidget(WidgetNodeType aWidgetType)
 {
-  MOZ_ASSERT(aWidgetType != MOZ_GTK_DROPDOWN_ENTRY,
-             "Callers should be passing MOZ_GTK_ENTRY");
-
   switch (aWidgetType) {
     case MOZ_GTK_WINDOW:
       return CreateWindowWidget();
@@ -1483,10 +1480,6 @@ GtkStyleContext*
 GetStyleContext(WidgetNodeType aNodeType, GtkTextDirection aDirection,
                 GtkStateFlags aStateFlags, StyleFlags aFlags)
 {
-  if (aNodeType == MOZ_GTK_DROPDOWN_ENTRY) {
-    aNodeType = MOZ_GTK_ENTRY;
-  }
-
   GtkStyleContext* style;
   if (gtk_check_version(3, 20, 0) != nullptr) {
     style = GetWidgetStyleInternal(aNodeType);

--- a/widget/gtk/gtk3drawing.cpp
+++ b/widget/gtk/gtk3drawing.cpp
@@ -1212,8 +1212,7 @@ moz_gtk_vpaned_paint(cairo_t *cr, GdkRectangle* rect,
 static gint
 moz_gtk_entry_paint(cairo_t *cr, GdkRectangle* rect,
                     GtkWidgetState* state,
-                    GtkStyleContext* style,
-                    WidgetNodeType widget)
+                    GtkStyleContext* style)
 {
     gint x = rect->x, y = rect->y, width = rect->width, height = rect->height;
     int draw_focus_outline_only = state->depressed; // NS_THEME_FOCUS_OUTLINE
@@ -1231,11 +1230,7 @@ moz_gtk_entry_paint(cairo_t *cr, GdkRectangle* rect,
     } else {
         gtk_render_background(style, cr, x, y, width, height);
     }
-
-    // Paint the border, except for 'menulist-textfield' that isn't focused:
-    if (widget != MOZ_GTK_DROPDOWN_ENTRY || state->focused) {
-      gtk_render_frame(style, cr, x, y, width, height);
-    }
+    gtk_render_frame(style, cr, x, y, width, height);
 
     return MOZ_GTK_SUCCESS;
 }
@@ -2356,9 +2351,8 @@ moz_gtk_get_widget_border(WidgetNodeType widget, gint* left, gint* top,
             return MOZ_GTK_SUCCESS;
         }
     case MOZ_GTK_ENTRY:
-    case MOZ_GTK_DROPDOWN_ENTRY:
         {
-            style = GetStyleContext(widget);
+            style = GetStyleContext(MOZ_GTK_ENTRY);
 
             // XXX: Subtract 1 pixel from the padding to account for the default
             // padding in forms.css. See bug 1187385.
@@ -2391,6 +2385,9 @@ moz_gtk_get_widget_border(WidgetNodeType widget, gint* left, gint* top,
         }
     case MOZ_GTK_TREE_HEADER_SORTARROW:
         w = GetWidget(MOZ_GTK_TREE_HEADER_SORTARROW);
+        break;
+    case MOZ_GTK_DROPDOWN_ENTRY:
+        w = GetWidget(MOZ_GTK_COMBOBOX_ENTRY_TEXTAREA);
         break;
     case MOZ_GTK_DROPDOWN_ARROW:
         w = GetWidget(MOZ_GTK_COMBOBOX_ENTRY_BUTTON);
@@ -3120,7 +3117,7 @@ moz_gtk_widget_paint(WidgetNodeType widget, cairo_t *cr,
             GtkStyleContext* style =
                 GetStyleContext(MOZ_GTK_SPINBUTTON_ENTRY, direction,
                                 GetStateFlagsFromGtkWidgetState(state));
-            gint ret = moz_gtk_entry_paint(cr, rect, state, style, widget);
+            gint ret = moz_gtk_entry_paint(cr, rect, state, style);
             return ret;
         }
         break;
@@ -3147,12 +3144,11 @@ moz_gtk_widget_paint(WidgetNodeType widget, cairo_t *cr,
                                                (GtkExpanderStyle) flags, direction);
         break;
     case MOZ_GTK_ENTRY:
-    case MOZ_GTK_DROPDOWN_ENTRY:
         {
             GtkStyleContext* style =
-                GetStyleContext(widget, direction,
+                GetStyleContext(MOZ_GTK_ENTRY, direction,
                                 GetStateFlagsFromGtkWidgetState(state));
-            gint ret = moz_gtk_entry_paint(cr, rect, state, style, widget);
+            gint ret = moz_gtk_entry_paint(cr, rect, state, style);
             return ret;
         }
     case MOZ_GTK_TEXT_VIEW:
@@ -3164,6 +3160,15 @@ moz_gtk_widget_paint(WidgetNodeType widget, cairo_t *cr,
     case MOZ_GTK_DROPDOWN_ARROW:
         return moz_gtk_combo_box_entry_button_paint(cr, rect,
                                                     state, flags, direction);
+        break;
+    case MOZ_GTK_DROPDOWN_ENTRY:
+        {
+            GtkStyleContext* style =
+                GetStyleContext(MOZ_GTK_COMBOBOX_ENTRY_TEXTAREA, direction,
+                                GetStateFlagsFromGtkWidgetState(state));
+            gint ret = moz_gtk_entry_paint(cr, rect, state, style);
+            return ret;
+        }
         break;
     case MOZ_GTK_CHECKBUTTON_CONTAINER:
     case MOZ_GTK_RADIOBUTTON_CONTAINER:

--- a/widget/gtk/nsNativeThemeGTK.cpp
+++ b/widget/gtk/nsNativeThemeGTK.cpp
@@ -1730,7 +1730,6 @@ nsNativeThemeGTK::GetMinimumWidgetSize(nsPresContext* aPresContext,
     }
     break;
 #if (MOZ_WIDGET_GTK == 3)
-  case NS_THEME_MENULIST_TEXTFIELD:
   case NS_THEME_NUMBER_INPUT:
   case NS_THEME_TEXTFIELD:
     {
@@ -1904,6 +1903,7 @@ nsNativeThemeGTK::ThemeSupportsWidget(nsPresContext* aPresContext,
   // Combobox dropdowns don't support native theming in vertical mode.
   case NS_THEME_MENULIST:
   case NS_THEME_MENULIST_TEXT:
+  case NS_THEME_MENULIST_TEXTFIELD:
     if (aFrame && aFrame->GetWritingMode().IsVertical()) {
       return false;
     }
@@ -1965,7 +1965,6 @@ nsNativeThemeGTK::ThemeSupportsWidget(nsPresContext* aPresContext,
   case NS_THEME_SCROLLBARTRACK_VERTICAL:
   case NS_THEME_SCROLLBARTHUMB_HORIZONTAL:
   case NS_THEME_SCROLLBARTHUMB_VERTICAL:
-  case NS_THEME_MENULIST_TEXTFIELD:
   case NS_THEME_NUMBER_INPUT:
   case NS_THEME_TEXTFIELD:
   case NS_THEME_TEXTFIELD_MULTILINE:

--- a/widget/windows/nsNativeThemeWin.cpp
+++ b/widget/windows/nsNativeThemeWin.cpp
@@ -141,14 +141,6 @@ GetCheckboxMargins(HANDLE theme, HDC hdc)
     return checkboxContent;
 }
 
-static COLORREF
-GetTextfieldFillColor(HANDLE theme, int32_t part, int32_t state)
-{
-    COLORREF color = {0};
-    GetThemeColor(theme, part, state, TMT_FILLCOLOR, &color);
-    return color;
-}
-
 static SIZE
 GetCheckboxBGSize(HANDLE theme, HDC hdc)
 {
@@ -1860,19 +1852,11 @@ RENDER_AGAIN:
            aWidgetType == NS_THEME_NUMBER_INPUT ||
            aWidgetType == NS_THEME_TEXTFIELD ||
            aWidgetType == NS_THEME_TEXTFIELD_MULTILINE) {
-    if (aWidgetType == NS_THEME_MENULIST_TEXTFIELD ||
-        state != TFS_EDITBORDER_FOCUSED) {
-      // We want 'menulist-textfield' to behave like 'textfield', except we
-      // don't want a border unless it's focused.  We have to handle the
-      // non-focused case manually here.
-      COLORREF color = GetTextfieldFillColor(theme, part, state);
-      HBRUSH brush = CreateSolidBrush(color);
-      ::FillRect(hdc, &widgetRect, brush);
-      DeleteObject(brush);
-    } else {
+    // Paint the border, except for 'menulist-textfield' that isn't focused:
+    if (aWidgetType != NS_THEME_MENULIST_TEXTFIELD ||
+        state == TFS_EDITBORDER_FOCUSED) {
       DrawThemeBackground(theme, hdc, part, state, &widgetRect, &clipRect);
     }
-
     if (state == TFS_EDITBORDER_DISABLED) {
       InflateRect(&widgetRect, -1, -1);
       ::FillRect(hdc, &widgetRect, reinterpret_cast<HBRUSH>(COLOR_BTNFACE+1));

--- a/widget/windows/nsNativeThemeWin.cpp
+++ b/widget/windows/nsNativeThemeWin.cpp
@@ -712,7 +712,6 @@ mozilla::Maybe<nsUXThemeClass> nsNativeThemeWin::GetThemeClass(uint8_t aWidgetTy
     case NS_THEME_CHECKBOX:
     case NS_THEME_GROUPBOX:
       return Some(eUXButton);
-    case NS_THEME_MENULIST_TEXTFIELD:
     case NS_THEME_NUMBER_INPUT:
     case NS_THEME_TEXTFIELD:
     case NS_THEME_TEXTFIELD_MULTILINE:
@@ -933,7 +932,6 @@ nsNativeThemeWin::GetThemePartAndState(nsIFrame* aFrame, uint8_t aWidgetType,
       // same as GBS_NORMAL don't bother supporting GBS_DISABLED.
       return NS_OK;
     }
-    case NS_THEME_MENULIST_TEXTFIELD:
     case NS_THEME_NUMBER_INPUT:
     case NS_THEME_TEXTFIELD:
     case NS_THEME_TEXTFIELD_MULTILINE: {
@@ -1848,16 +1846,11 @@ RENDER_AGAIN:
     DrawThemeBGRTLAware(theme, hdc, part, state,
                         &widgetRect, &clipRect, IsFrameRTL(aFrame));
   }
-  else if (aWidgetType == NS_THEME_MENULIST_TEXTFIELD ||
-           aWidgetType == NS_THEME_NUMBER_INPUT ||
+  else if (aWidgetType == NS_THEME_NUMBER_INPUT ||
            aWidgetType == NS_THEME_TEXTFIELD ||
            aWidgetType == NS_THEME_TEXTFIELD_MULTILINE) {
-    // Paint the border, except for 'menulist-textfield' that isn't focused:
-    if (aWidgetType != NS_THEME_MENULIST_TEXTFIELD ||
-        state == TFS_EDITBORDER_FOCUSED) {
-      DrawThemeBackground(theme, hdc, part, state, &widgetRect, &clipRect);
-    }
-    if (state == TFS_EDITBORDER_DISABLED) {
+    DrawThemeBackground(theme, hdc, part, state, &widgetRect, &clipRect);
+     if (state == TFS_EDITBORDER_DISABLED) {
       InflateRect(&widgetRect, -1, -1);
       ::FillRect(hdc, &widgetRect, reinterpret_cast<HBRUSH>(COLOR_BTNFACE+1));
     }
@@ -2053,8 +2046,7 @@ nsNativeThemeWin::GetWidgetBorder(nsDeviceContext* aContext,
       aResult->left = 0;
   }
 
-  if (aFrame && (aWidgetType == NS_THEME_MENULIST_TEXTFIELD ||
-                 aWidgetType == NS_THEME_NUMBER_INPUT ||
+  if (aFrame && (aWidgetType == NS_THEME_NUMBER_INPUT ||
                  aWidgetType == NS_THEME_TEXTFIELD ||
                  aWidgetType == NS_THEME_TEXTFIELD_MULTILINE)) {
     nsIContent* content = aFrame->GetContent();
@@ -2141,8 +2133,7 @@ nsNativeThemeWin::GetWidgetPadding(nsDeviceContext* aContext,
     return ok;
   }
 
-  if (aWidgetType == NS_THEME_MENULIST_TEXTFIELD ||
-      aWidgetType == NS_THEME_NUMBER_INPUT ||
+  if (aWidgetType == NS_THEME_NUMBER_INPUT ||
       aWidgetType == NS_THEME_TEXTFIELD ||
       aWidgetType == NS_THEME_TEXTFIELD_MULTILINE ||
       aWidgetType == NS_THEME_MENULIST)
@@ -2159,8 +2150,7 @@ nsNativeThemeWin::GetWidgetPadding(nsDeviceContext* aContext,
    * Instead, we add 2px padding for the contents and fix this. (Used to be 1px
    * added, see bug 430212)
    */
-  if (aWidgetType == NS_THEME_MENULIST_TEXTFIELD ||
-      aWidgetType == NS_THEME_NUMBER_INPUT ||
+  if (aWidgetType == NS_THEME_NUMBER_INPUT ||
       aWidgetType == NS_THEME_TEXTFIELD ||
       aWidgetType == NS_THEME_TEXTFIELD_MULTILINE) {
     aResult->top = aResult->bottom = 2;
@@ -2304,7 +2294,6 @@ nsNativeThemeWin::GetMinimumWidgetSize(nsPresContext* aPresContext, nsIFrame* aF
 
   switch (aWidgetType) {
     case NS_THEME_GROUPBOX:
-    case NS_THEME_MENULIST_TEXTFIELD:
     case NS_THEME_NUMBER_INPUT:
     case NS_THEME_TEXTFIELD:
     case NS_THEME_TOOLBOX:
@@ -3751,12 +3740,8 @@ RENDER_AGAIN:
     case NS_THEME_LISTBOX:
     case NS_THEME_MENULIST:
     case NS_THEME_MENULIST_TEXTFIELD: {
-      // Paint the border, except for 'menulist-textfield' that isn't focused:
-      if (aWidgetType != NS_THEME_MENULIST_TEXTFIELD || focused) {
-        // Draw inset edge
-        ::DrawEdge(hdc, &widgetRect, EDGE_SUNKEN, BF_RECT | BF_ADJUST);
-      }
-
+      // Draw inset edge
+      ::DrawEdge(hdc, &widgetRect, EDGE_SUNKEN, BF_RECT | BF_ADJUST);
       EventStates eventState = GetContentState(aFrame, aWidgetType);
 
       // Fill in background


### PR DESCRIPTION
This fixes #2168.

Seems that something went wrong with doing that. Anyway looks like that menulist-textfield is deprecated, so we don't need that changes, which got reverted. 