### PR TITLE
[Classic] Initial config for GitHub Actions builds on classic branch

### DIFF
--- a/.github/workflows/classic.yml
+++ b/.github/workflows/classic.yml
@@ -1,0 +1,103 @@
+name: Build Classic
+
+on:
+    push:
+        paths:
+          - 'browser/config/version_display.txt'
+    pull_request:
+
+jobs:
+    build:
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [macos-10.15, ubuntu-20.04]
+
+        env:
+            ENABLE_ARTIFACTS_MODE: "true"
+            MOZCONFIG: "./.mozconfig-ga-classic"
+            SHELL: "/bin/bash"
+
+        runs-on: ${{ matrix.os }}
+        steps:
+          - name: Set up Xcode version
+            uses: maxim-lobanov/setup-xcode@v1
+            with:
+              xcode-version: '11.2.1'
+            if: startsWith(matrix.os, 'macos')
+
+          - name: Set up Python version
+            uses: actions/setup-python@v2
+            with:
+              python-version: '3.8'
+
+          - name: Checkout branch
+            uses: actions/checkout@v2
+
+          - name: Cache for macOS
+            uses: actions/cache@v2
+            with:
+              path: |
+                ~/Library/Caches/ccache
+              key: ${{ runner.os }}-${{ hashFiles('**/browser/config/version_display.txt') }}
+            if: startsWith(matrix.os, 'macos')
+
+          - name: Cache for Linux
+            uses: actions/cache@v2
+            with:
+              path: |
+                ~/.ccache
+              key: ${{ runner.os }}-${{ hashFiles('**/browser/config/version_display.txt') }}
+            if: startsWith(matrix.os, 'ubuntu')
+
+          - name: Cleanup useless paths
+            run: |
+              sudo rm -rf /usr/share/dotnet
+              sudo rm -rf /opt/ghc
+              sudo rm -rf /usr/local/share/boost
+              sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+            if: startsWith(matrix.os, 'ubuntu')
+
+          - name: Brew dependencies
+            run: |
+              brew update
+              brew install autoconf@2.13 ccache make nasm yasm
+            if: startsWith(matrix.os, 'macos')
+
+          - name: Apt-get dependencies
+            run: |
+              sudo apt-get update
+              sudo apt-get install autoconf2.13 ccache libasound2-dev \
+              libdbus-glib-1-dev libdrm-dev libfreetype6-dev libgconf2-dev \
+              libglib2.0-dev libgtk2.0-dev libgtk-3-dev libpangocairo-1.0-0 \
+              libpulse-dev libx11-xcb-dev libxkbcommon-dev nasm yasm
+            if: startsWith(matrix.os, 'ubuntu')
+
+          - name: Get SDK
+            run: |
+              wget https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.12.sdk.tar.xz
+              tar -xvf MacOSX10.12.sdk.tar.xz
+            if: startsWith(matrix.os, 'macos')
+
+          - name: Mach build
+            run: |
+              ./mach build
+
+          - name: Mach package
+            run: |
+              ./mach package
+            if: env.ENABLE_ARTIFACTS_MODE == 'true'
+
+          - name: Upload macOS artifact
+            uses: actions/upload-artifact@v2
+            with:
+              name: Artifact Classic macOS ${{ github.run_id }}
+              path: ./objdir-*/dist/*.dmg
+            if: startsWith(matrix.os, 'macos') && env.ENABLE_ARTIFACTS_MODE == 'true'
+
+          - name: Upload Linux artifact
+            uses: actions/upload-artifact@v2
+            with:
+              name: Artifact Classic Linux ${{ github.run_id }}
+              path: ./objdir-*/dist/*.tar.bz2
+            if: startsWith(matrix.os, 'ubuntu') && env.ENABLE_ARTIFACTS_MODE == 'true'

--- a/.mozconfig-ga
+++ b/.mozconfig-ga
@@ -3,10 +3,11 @@
 if test $(uname -s) = Darwin; then
 	ac_add_options --target=x86_64-apple-darwin
 	export STRIP=strip
-	ac_add_options --enable-macos-target=10.9
+	ac_add_options --enable-macos-target=10.7
 	ac_add_options --with-macos-sdk=$PWD/MacOSX10.12.sdk
 elif test $(uname -s) = MINGW32_NT-6.2; then
 	ac_add_options --target=x86_64-pc-mingw32
+	ac_add_options --with-visual-studio-version=2017
 	export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
 	export WIN_UCRT_REDIST_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64"
 elif test $(uname -s) = Linux; then
@@ -43,7 +44,7 @@ fi
 if test $(uname -s) = MINGW32_NT-6.2; then
 	ac_add_options --enable-optimize="-O2 -Qvec -w"
 else
-	ac_add_options --enable-optimize="-O3 -march=core2 -w"
+	ac_add_options --enable-optimize="-O3 -march=nocona -mtune=nocona -w"
 fi
 
 ac_add_options --disable-crashreporter
@@ -53,13 +54,13 @@ ac_add_options --disable-profiling
 ac_add_options --disable-signmar
 ac_add_options --disable-stylo
 ac_add_options --disable-tests
-ac_add_options --disable-updater
 ac_add_options --disable-verify-mar
 ac_add_options --enable-application=browser
 ac_add_options --enable-ccache=ccache
 ac_add_options --enable-eme=widevine
 ac_add_options --enable-release
 ac_add_options --enable-rust-simd
+ac_add_options --enable-updater
 ac_add_options --enable-update-channel=release
 ac_add_options --with-app-name=waterfox
 ac_add_options --with-app-basename=Waterfox

--- a/.mozconfig-ga-classic
+++ b/.mozconfig-ga-classic
@@ -1,0 +1,74 @@
+# Config for GitHub Actions
+
+if test $(uname -s) = Darwin; then
+	ac_add_options --target=x86_64-apple-darwin
+	export STRIP=strip
+	ac_add_options --enable-macos-target=10.9
+	ac_add_options --with-macos-sdk=$PWD/MacOSX10.12.sdk
+elif test $(uname -s) = MINGW32_NT-6.2; then
+	ac_add_options --target=x86_64-pc-mingw32
+	export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
+	export WIN_UCRT_REDIST_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64"
+elif test $(uname -s) = Linux; then
+	if test $(uname -m) = x86_64; then
+		if test -d "$HOME/.mozbuild/clang/bin"; then
+			export CC=$HOME/.mozbuild/clang/bin/clang
+			export CXX=$HOME/.mozbuild/clang/bin/clang++
+		else
+			export CC=clang
+			export CXX=clang++
+		fi
+		if test -f "$HOME/.mozbuild/nasm/nasm"; then
+			export NASM=$HOME/.mozbuild/nasm/nasm
+		fi
+		ac_add_options --target=x86_64-pc-linux-gnu
+	elif test $(uname -m) = ppc64le; then
+		export CC=gcc
+		export CXX=g++
+		ac_add_options --enable-optimize="-O2 -mcpu=power9"
+		ac_add_options --target=powerpc64le-unknown-linux-gnu
+	fi
+	ac_add_options --enable-pulseaudio
+	ac_add_options --enable-alsa
+fi
+
+if test $(uname -s) = MINGW32_NT-6.2; then
+	X=$(wmic cpu get NumberOfLogicalProcessors /Format:List | cut -d'=' -f2 | xargs)
+	mk_add_options MOZ_MAKE_FLAGS=-j${X}
+else
+	X=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
+	mk_add_options MOZ_MAKE_FLAGS=-j${X}
+fi
+
+if test $(uname -s) = MINGW32_NT-6.2; then
+	ac_add_options --enable-optimize="-O2 -Qvec -w"
+else
+	ac_add_options --enable-optimize="-O3 -march=core2 -w"
+fi
+
+ac_add_options --disable-crashreporter
+ac_add_options --disable-js-shell
+ac_add_options --disable-maintenance-service
+ac_add_options --disable-profiling
+ac_add_options --disable-signmar
+ac_add_options --disable-stylo
+ac_add_options --disable-tests
+ac_add_options --disable-updater
+ac_add_options --disable-verify-mar
+ac_add_options --enable-application=browser
+ac_add_options --enable-ccache=ccache
+ac_add_options --enable-eme=widevine
+ac_add_options --enable-release
+ac_add_options --enable-rust-simd
+ac_add_options --enable-update-channel=release
+ac_add_options --with-app-name=waterfox
+ac_add_options --with-app-basename=Waterfox
+ac_add_options --with-branding=browser/branding/unofficial
+ac_add_options --with-distribution-id=org.waterfoxproject
+
+export MOZ_GECKO_PROFILER=
+export MOZ_ENABLE_PROFILER_SPS=
+export MOZ_PROFILING=
+export MOZ_INCLUDE_SOURCE_INFO=1
+mk_add_options AUTOCLOBBER=1
+mk_add_options MOZ_OBJDIR=objdir-classic


### PR DESCRIPTION
GitHub Actions is completely free and unlimited for open source projects. I think it would be a good idea to add support for this on classic branch to simplify the testing of pull requests (as similar projects do).

- Unfortunately there is no Windows virtual environment on the list, because it is not easy to prepare dependencies there.
- Trigger on "version_display.txt" is needed to checkup branch and rebuild virtual machine cache.
- Artifacts can be disabled via ENABLE_ARTIFACTS_MODE if required.