### PR TITLE
[Classic] Hard-block old mesa/nouveau versions

### DIFF
--- a/widget/GfxInfoX11.cpp
+++ b/widget/GfxInfoX11.cpp
@@ -362,7 +362,11 @@ GfxInfo::GetFeatureStatusImpl(int32_t aFeature,
             aSuggestedDriverVersion.AssignLiteral("Mesa 8.1");
           }
         }
-
+        else if (mIsNouveau && version(mMajorVersion, mMinorVersion) < version(11,0)) {
+          *aStatus = nsIGfxInfo::FEATURE_BLOCKED_DRIVER_VERSION;
+          aFailureId = "FEATURE_FAILURE_OLD_NOUVEAU";
+          aSuggestedDriverVersion.AssignLiteral("Mesa 11.0");
+        }
       } else if (mIsNVIDIA) {
         if (version(mMajorVersion, mMinorVersion, mRevisionVersion) < version(257,21)) {
           *aStatus = nsIGfxInfo::FEATURE_BLOCKED_DRIVER_VERSION;


### PR DESCRIPTION
So https://hg.mozilla.org/releases/mozilla-esr78/rev/17211c48aea7faa406234fb08bd90b73ad4e7537 can be removed from https://github.com/MrAlex94/Waterfox/wiki/Security-Patches-not-in-Classic now :smile:

PS: `Bug 1368981` can be also removed from https://github.com/MrAlex94/Waterfox/wiki/Security-Patches-not-in-Classic, cuz that was fixed in https://github.com/MrAlex94/Waterfox/commit/99322ca634de2532421d3117abb19fb0503ce221 (showModalDialog removed). 
Some other things tagged as `SECURITY PATCHES UNABLE TO FIND` also looks like fixed, so maybe you need to look at that again.