### PR TITLE
[Classic] Fix CVE-2018-5113

### DIFF
--- a/toolkit/components/extensions/schemas/identity.json
+++ b/toolkit/components/extensions/schemas/identity.json
@@ -162,7 +162,7 @@
             "name": "details",
             "type": "object",
             "properties": {
-              "url": {"type": "string"},
+              "url": {"$ref": "manifest.HttpURL"},
               "interactive": {"type": "boolean", "optional": true}
             }
           },
@@ -185,7 +185,7 @@
         "description": "Generates a redirect URL to be used in |launchWebAuthFlow|.",
         "parameters": [
           {
-            "name": " path",
+            "name": "path",
             "type": "string",
             "default": "",
             "optional": true,


### PR DESCRIPTION
Another one from the [big list](https://github.com/MrAlex94/Waterfox/wiki/Security-Patches-not-in-Classic).
It works great, on console I see now that it checks if it's http(s) only.