### PR TITLE
[Classic] Fix unified debug build bustage.

### DIFF
--- a/dom/canvas/WebGLVertexAttribData.cpp
+++ b/dom/canvas/WebGLVertexAttribData.cpp
@@ -7,6 +7,7 @@
 
 #include "GLContext.h"
 #include "WebGLBuffer.h"
+#include "WebGLContext.h"
 
 namespace mozilla {
 


### PR DESCRIPTION
After fetching latest changes unified debug build bustage happens. Apparently it's because of some files got removed and files are concatenated, so now we need to add one include directive. That's one of the [drawback of unified compilation](https://repo.palemoon.org/MoonchildProductions/UXP/issues/80). 

Maybe de-unifying would be good, just like Moonchild trying to do it and GitHub Actions would be good for testing that.