### PR TITLE
[Classic] Improve GA config

### DIFF
--- a/.github/workflows/classic.yml
+++ b/.github/workflows/classic.yml
@@ -5,13 +5,14 @@ on:
         paths:
           - 'browser/config/version_display.txt'
     pull_request:
+    workflow_dispatch:
 
 jobs:
     build:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-10.15, ubuntu-20.04]
+                os: [macos-10.15, ubuntu-18.04]
 
         env:
             ENABLE_ARTIFACTS_MODE: "true"
@@ -25,11 +26,6 @@ jobs:
             with:
               xcode-version: '11.2.1'
             if: startsWith(matrix.os, 'macos')
-
-          - name: Set up Python version
-            uses: actions/setup-python@v2
-            with:
-              python-version: '3.8'
 
           - name: Checkout branch
             uses: actions/checkout@v2
@@ -70,7 +66,8 @@ jobs:
               sudo apt-get install autoconf2.13 ccache libasound2-dev \
               libdbus-glib-1-dev libdrm-dev libfreetype6-dev libgconf2-dev \
               libglib2.0-dev libgtk2.0-dev libgtk-3-dev libpangocairo-1.0-0 \
-              libpulse-dev libx11-xcb-dev libxkbcommon-dev nasm yasm
+              libpulse-dev libx11-xcb-dev libxkbcommon-dev nasm-mozilla \
+              python2.7 python3 yasm
             if: startsWith(matrix.os, 'ubuntu')
 
           - name: Get SDK

--- a/.mozconfig-ga
+++ b/.mozconfig-ga
@@ -1,50 +1,36 @@
 # Config for GitHub Actions
 
 if test $(uname -s) = Darwin; then
-	ac_add_options --target=x86_64-apple-darwin
-	export STRIP=strip
-	ac_add_options --enable-macos-target=10.7
-	ac_add_options --with-macos-sdk=$PWD/MacOSX10.12.sdk
+    ac_add_options --target=x86_64-apple-darwin
+    ac_add_options --enable-macos-target=10.7
+    ac_add_options --with-macos-sdk=$PWD/MacOSX10.12.sdk
+    export CXXFLAGS="-stdlib=libc++"
 elif test $(uname -s) = MINGW32_NT-6.2; then
-	ac_add_options --target=x86_64-pc-mingw32
-	ac_add_options --with-visual-studio-version=2017
-	export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
-	export WIN_UCRT_REDIST_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64"
+    ac_add_options --target=x86_64-pc-mingw32
+    ac_add_options --with-visual-studio-version=2017
+    export WIN32_REDIST_DIR="/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Redist/MSVC/14.16.27012/x64/Microsoft.VC141.CRT"
+    export WIN_UCRT_REDIST_DIR="/c/Program Files (x86)/Windows Kits/10/Redist/ucrt/DLLs/x64"
 elif test $(uname -s) = Linux; then
-	if test $(uname -m) = x86_64; then
-		if test -d "$HOME/.mozbuild/clang/bin"; then
-			export CC=$HOME/.mozbuild/clang/bin/clang
-			export CXX=$HOME/.mozbuild/clang/bin/clang++
-		else
-			export CC=clang
-			export CXX=clang++
-		fi
-		if test -f "$HOME/.mozbuild/nasm/nasm"; then
-			export NASM=$HOME/.mozbuild/nasm/nasm
-		fi
-		ac_add_options --target=x86_64-pc-linux-gnu
-	elif test $(uname -m) = ppc64le; then
-		export CC=gcc
-		export CXX=g++
-		ac_add_options --enable-optimize="-O2 -mcpu=power9"
-		ac_add_options --target=powerpc64le-unknown-linux-gnu
-	fi
-	ac_add_options --enable-pulseaudio
-	ac_add_options --enable-alsa
+    ac_add_options --target=x86_64-pc-linux-gnu
+    ac_add_options --enable-pulseaudio
+    ac_add_options --enable-alsa
+    export CC=clang
+    export CXX=clang++
+    export NASM=/usr/lib/nasm-mozilla/bin/nasm
 fi
 
 if test $(uname -s) = MINGW32_NT-6.2; then
-	X=$(wmic cpu get NumberOfLogicalProcessors /Format:List | cut -d'=' -f2 | xargs)
-	mk_add_options MOZ_MAKE_FLAGS=-j${X}
+    X=$(wmic cpu get NumberOfLogicalProcessors /Format:List | cut -d'=' -f2 | xargs)
+    mk_add_options MOZ_MAKE_FLAGS=-j${X}
 else
-	X=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
-	mk_add_options MOZ_MAKE_FLAGS=-j${X}
+    X=$(getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
+    mk_add_options MOZ_MAKE_FLAGS=-j${X}
 fi
 
 if test $(uname -s) = MINGW32_NT-6.2; then
-	ac_add_options --enable-optimize="-O2 -Qvec -w"
+    ac_add_options --enable-optimize="-O2 -Qvec -w"
 else
-	ac_add_options --enable-optimize="-O3 -march=nocona -mtune=nocona -w"
+    ac_add_options --enable-optimize="-O3 -march=nocona -mtune=nocona -w"
 fi
 
 ac_add_options --disable-crashreporter
@@ -55,6 +41,7 @@ ac_add_options --disable-signmar
 ac_add_options --disable-stylo
 ac_add_options --disable-tests
 ac_add_options --disable-verify-mar
+
 ac_add_options --enable-application=browser
 ac_add_options --enable-ccache=ccache
 ac_add_options --enable-eme=widevine
@@ -62,6 +49,7 @@ ac_add_options --enable-release
 ac_add_options --enable-rust-simd
 ac_add_options --enable-updater
 ac_add_options --enable-update-channel=release
+
 ac_add_options --with-app-name=waterfox
 ac_add_options --with-app-basename=Waterfox
 ac_add_options --with-branding=browser/branding/unofficial


### PR DESCRIPTION
* Switched to lowest supported Ubuntu version (16.04 will be removed soon, so chose 18.04)
* Added possibility to manually run Action (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
* Cleaned up mozconfig-ga and fixed for MacOS

However see https://github.com/phracker/MacOSX-SDKs/issues/26.
Anyway, as I see on https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#installed-sdks, that SDK should be already bundled with Xcode.