### PR TITLE
[Classic] Add Docker image for building on GH Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Build Docker image
+
+on:
+  workflow_dispatch: null
+  schedule:
+    - cron: "00 00 20 * *"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: github-actions[bot]
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Downcase REPO
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.GA
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO }}_docker_img:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile.GA
+++ b/Dockerfile.GA
@@ -1,0 +1,48 @@
+FROM centos:7
+ENV llvm_ver="7.0"
+ENV nasm_ver="2.15.05"
+ENV git_ver="2.33.0"
+ENV PATH="/opt/rh/llvm-toolset-${llvm_ver}/root/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/rh/llvm-toolset-${llvm_ver}/root/usr/lib64:${LD_LIBRARY_PATH}"
+RUN yum -y install "deltarpm" "centos-release-scl-rh" "epel-release"
+RUN yum -y install "perl(Env)" "autoconf" "automake" "make" "xz" "wget"
+#
+# Add Springdale SCL repo, which contains newer llvm toolchains (8, 9, 10 and 11)
+# ENV SPRINGDALE_SCL="springdale-SCL-7-2.sdl7.1.noarch.rpm"
+# RUN yum -y install "rpm2cpio" "bsdtar"
+# RUN wget "http://springdale.princeton.edu/data/springdale/7/x86_64/os/Packages/${SPRINGDALE_SCL}"
+# RUN rpm2cpio "${SPRINGDALE_SCL}" | bsdtar -xf -
+# RUN rm -rf "${SPRINGDALE_SCL}"
+# RUN rpm --import "http://springdale.princeton.edu/data/springdale/7/x86_64/os/RPM-GPG-KEY-springdale"
+# RUN yum repolist
+#
+RUN yum -y update
+RUN yum -y install "llvm-toolset-${llvm_ver}-clang" "llvm-toolset-${llvm_ver}-llvm-devel"
+RUN clang --version
+RUN yum -y install "ccache" "which" "pkgconfig" "python2-devel" "python36" "alsa-lib-devel" "autoconf213" "pkgconfig(gl)" "pkgconfig(dbus-glib-1)" "rust" "cargo" "libnotify-devel" "libproxy-devel" "startup-notification-devel" "unzip" "zip" "pkgconfig(xt)" "yasm" "pkgconfig(gdk-x11-2.0)" "pkgconfig(glib-2.0)" "pkgconfig(gobject-2.0)" "pkgconfig(gtk+-2.0)" "pkgconfig(gtk+-3.0)" "pkgconfig(gtk+-unix-print-2.0)" "pkgconfig(gtk+-unix-print-3.0)" "libcurl-devel" "pkgconfig(libffi)" "pkgconfig(libpulse)" "pkgconfig(jack)" "libdrm-devel" "pkgconfig(gconf-2.0)" "bzip2"
+# Build nasm
+RUN mkdir -p ~/nasm/
+WORKDIR "$HOME/nasm"
+RUN wget "https://www.nasm.us/pub/nasm/releasebuilds/${nasm_ver}/nasm-${nasm_ver}.tar.xz"
+RUN tar -xf nasm-${nasm_ver}.tar.xz
+WORKDIR "$HOME/nasm/nasm-${nasm_ver}"
+RUN ./configure --prefix=/usr
+RUN make all
+RUN make install
+RUN nasm --version
+# Build git (we need newer git version than it's on repo, cuz otherwise it will download using REST API and we won't receive source info)
+RUN mkdir -p ~/git_pkg/
+WORKDIR "$HOME/git_pkg"
+RUN wget "https://kernel.org/pub/software/scm/git/git-${git_ver}.tar.xz"
+RUN tar -xf git-${git_ver}.tar.xz
+WORKDIR "$HOME/git_pkg/git-${git_ver}"
+RUN make configure
+RUN ./configure --prefix=/usr
+RUN make all
+RUN make install
+RUN git --version
+WORKDIR "$HOME"
+# Cleanup
+RUN rm -rf ./git_pkg/*
+RUN rm -rf ./nasm/*
+RUN yum clean all


### PR DESCRIPTION
Thanks to that you could build on CentOS 7 and lower requirements of GNU libc (glibc/libc6) to 2.17.

It's set to build Docker image at 00:00 on 20 day-of-month and it's possible to trigger manually through Actions tab.

Maybe if you will add installing few additional packages, then that could be used also for Waterfox G3.

PS: I set 7.0 as LLVM toolset version, but if you want newer, then you need to uncomment commands which adds Springdale Linux repo (which also works great on CentOS), which contains newer LLVM toolset versions.
Setting LD_LIBRARY_PATH is needed, because otherwise Clang complains that can't find LLVM libs.

If you will trigger building that after merging, then I will send next PR with changed config for building Classic.