### PR TITLE
[Classic] Mozilla Foundation Security Advisory 2021-39

### DIFF
--- a/dom/ipc/ContentChild.cpp
+++ b/dom/ipc/ContentChild.cpp
@@ -3256,10 +3256,11 @@ mozilla::ipc::IPCResult
 ContentChild::RecvGetFilesResponse(const nsID& aUUID,
                                    const GetFilesResponseResult& aResult)
 {
-  GetFilesHelperChild* child = mGetFilesPendingRequests.GetWeak(aUUID);
+  RefPtr<GetFilesHelperChild> child;
+
   // This object can already been deleted in case DeleteGetFilesRequest has
   // been called when the response was sending by the parent.
-  if (!child) {
+  if (!mGetFilesPendingRequests.Remove(aUUID, getter_AddRefs(child))) {
     return IPC_OK();
   }
 
@@ -3279,8 +3280,6 @@ ContentChild::RecvGetFilesResponse(const nsID& aUUID,
 
     child->Finished(succeeded ? NS_OK : NS_ERROR_OUT_OF_MEMORY);
   }
-
-  mGetFilesPendingRequests.Remove(aUUID);
   return IPC_OK();
 }
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -1554,6 +1554,7 @@ pref("network.protocol-handler.external.hcp", false);
 pref("network.protocol-handler.external.vbscript", false);
 pref("network.protocol-handler.external.javascript", false);
 pref("network.protocol-handler.external.data", false);
+pref("network.protocol-handler.external.mk", false);
 pref("network.protocol-handler.external.ms-help", false);
 pref("network.protocol-handler.external.shell", false);
 pref("network.protocol-handler.external.vnd.ms.radio", false);

--- a/xpcom/threads/TimerThread.cpp
+++ b/xpcom/threads/TimerThread.cpp
@@ -170,6 +170,7 @@ public:
   void operator delete(void* aPtr)
   {
     sAllocator->Free(aPtr);
+    sAllocatorUsers--;
     DeleteAllocatorIfNeeded();
   }
 
@@ -193,7 +194,6 @@ private:
   {
     MOZ_ASSERT(!sCanDeleteAllocator || sAllocatorUsers > 0,
                "This will result in us attempting to deallocate the nsTimerEvent allocator twice");
-    sAllocatorUsers--;
   }
 
   RefPtr<nsTimerImpl> mTimer;


### PR DESCRIPTION
Seems that @MrAlex94 forgot about Classic, so here are security fixes for Classic.

I did almost all from this MFSA, seems that only [Bug 1724101](https://github.com/WaterfoxCo/Waterfox/commit/8aaeca4a7e1ab8c1d575559f6eec1e13b7d43818) left to do.