### PR TITLE
[Classic] Build Docker image on pull request

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Build Docker image
 
 on:
+  pull_request:
   workflow_dispatch: null
   schedule:
     - cron: "00 00 20 * *"
@@ -8,6 +9,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Looks like that's not possible to manually trigger workflow through UI if it's on non-default branch.

However if workflow was already triggered by push event or pull request, then it's possible to trigger that with GitHub CLI => 
`gh workflow run docker.yml --ref classic`.

I don't know if building Docker image on every pull request is really needed, but approving workflow should be enough to start building Docker image for first time (or otherwise we will need to wait very long to start that), then it will autobuild on every 20 day of month.

Alternatively workflow file could be moved to default branch, so it will be possible to manually trigger it through Actions UI.