### PR TITLE
[Classic] Improve Docker image 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Downcase REPO
         run: |
           echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+      - name: Set date string for version
+        run: |
+          echo "version_date=$(date +'%Y%m')" >> $GITHUB_ENV
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -38,6 +41,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ env.REPO }}_docker_img:latest
+            ghcr.io/${{ env.REPO }}_docker_img:${{ env.version_date }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       - # Temp fix

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request: null
   workflow_dispatch: null
   schedule:
-    - cron: "00 00 20 * *"
+    - cron: "0 0 8 * *"
 
 jobs:
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Build Docker image
 
 on:
+  pull_request: null
   workflow_dispatch: null
   schedule:
     - cron: "00 00 20 * *"
@@ -34,7 +35,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.GA
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ env.REPO }}_docker_img:latest
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile.GA
+++ b/Dockerfile.GA
@@ -42,6 +42,11 @@ RUN make all
 RUN make install
 RUN git --version
 WORKDIR "$HOME"
+# Install packages for releases based on 78+
+RUN cargo install cbindgen
+RUN wget -qO- https://rpm.nodesource.com/setup_14.x | bash -
+RUN yum install -y nodejs
+RUN node --version
 # Cleanup
 RUN rm -rf ./git_pkg/*
 RUN rm -rf ./nasm/*


### PR DESCRIPTION
* Changed cron to run every eight day of month
* Added building Docker image on every pull request too, but disabled pushing for pull requests trigger
* Added additional packages for releases based on 78+

If you want to start using Docker image, then it needs to be pushed to GitHub Container Registry. It can be done through GitHub Actions, but won't work on pull request trigger, so you'll need to trigger it manually with [GitHub CLI](https://github.com/cli/cli/releases) => `gh workflow run docker.yml --ref classic` or wait for cron launch, so it will run automatically. 
There is also another way without using GitHub CLI, you can move workflow file to default branch and then you will have the option to run it manually through GH Actions tab.

Maybe you should also go to **org Settings => Packages => Container Creation** and check **Public**.