### PR TITLE
[Classic] Fix crashes

### DIFF
--- a/security/sandbox/linux/SandboxFilter.cpp
+++ b/security/sandbox/linux/SandboxFilter.cpp
@@ -285,6 +285,9 @@ public:
     case __NR_clone:
       return ClonePolicy(InvalidSyscall());
 
+    case __NR_clone3:
+      return Error(ENOSYS);
+
       // More thread creation.
 #ifdef __NR_set_robust_list
     case __NR_set_robust_list:
@@ -997,6 +1000,9 @@ public:
       // usually do something reasonable on error.
     case __NR_clone:
       return ClonePolicy(Error(EPERM));
+
+    case __NR_clone3:
+      return Error(ENOSYS);
 
 #ifdef __NR_fadvise64
     case __NR_fadvise64:

--- a/widget/GfxInfoBase.cpp
+++ b/widget/GfxInfoBase.cpp
@@ -180,6 +180,9 @@ GetPrefNameForFeature(int32_t aFeature)
     case nsIGfxInfo::FEATURE_D3D11_KEYED_MUTEX:
       name = BLACKLIST_PREF_BRANCH "d3d11.keyed.mutex";
       break;
+    case nsIGfxInfo::FEATURE_WEBRENDER:
+      // no WebRender in 56
+      break;
     case nsIGfxInfo::FEATURE_VP8_HW_DECODE:
     case nsIGfxInfo::FEATURE_VP9_HW_DECODE:
     case nsIGfxInfo::FEATURE_DX_INTEROP2:

--- a/widget/nsIGfxInfo.idl
+++ b/widget/nsIGfxInfo.idl
@@ -129,6 +129,8 @@ interface nsIGfxInfo : nsISupports
   const long FEATURE_ADVANCED_LAYERS = 22;
   /* Whether D3D11 keyed mutex is supported, starting in 56 */
   const long FEATURE_D3D11_KEYED_MUTEX = 23;
+  /* Whether WebRender is supported, starting in 62 */
+  const long FEATURE_WEBRENDER = 24;
   /* the maximum feature value. */
   const long FEATURE_MAX_VALUE = FEATURE_D3D11_KEYED_MUTEX;
 


### PR DESCRIPTION
This fixes crashes if someone has glibc/libc6 2.34 (#2267) and should also get rid of `Crash Annotation GraphicsCriticalError: |[0][GFX1-]: Unrecognized feature WEBRENDER `.

Confirmed on openSUSE Tumbleweed.