### PR TITLE
Fix generating checksum for Classic release

### DIFF
--- a/.github/workflows/classic-release.yml
+++ b/.github/workflows/classic-release.yml
@@ -332,7 +332,7 @@ jobs:
           mkdir ./dist
           mv ./objdir-*/dist/Artifact_Classic_*_${{ github.run_id }}/objdir-*/dist/waterfox*.tar.bz2 ./dist/
           mv ./objdir-*/dist/Artifact_Classic_*_${{ github.run_id }}/objdir-*/dist/waterfox-classic/Waterfox*.dmg ./dist/
-          mv ./objdir-*/dist/install/sea/*.exe ./dist/
+          mv ./objdir-*/dist/Artifact_Classic_*_${{ github.run_id }}/objdir-*/dist/install/sea/*.exe ./dist/
           cd ./dist/
           checksumFile=$(basename waterfox*.tar.bz2 | sed 's/.tar.bz2//g' | sed 's/$/.sha256/g')
           sha256sum waterfox*.tar.bz2 | tee -a "$checksumFile"


### PR DESCRIPTION
Apparently it failed to do that, cuz path for Windows file was wrong.

PS: You have mistake on website, should be `glibc` instead of `GLib` (`https://wiki.zmanda.com/index.php/Amanda:What%27s_the_difference_between_glib_and_glibc%3F`)
![2021-10-07_16-17](https://user-images.githubusercontent.com/19818572/136403167-a0ee9d43-f61c-4e0a-966f-0a620ad6653c.png)
