### PR TITLE
Fix Wayland build errors

### DIFF
--- a/widget/gtk/nsClipboardWayland.h
+++ b/widget/gtk/nsClipboardWayland.h
@@ -37,6 +37,8 @@ class DataOffer {
   nsTArray<GdkAtom> mTargetMIMETypes;
 };
 
+class nsWaylandDragContext;
+
 class WaylandDataOffer : public DataOffer {
  public:
   explicit WaylandDataOffer(wl_data_offer* aWaylandDataOffer);


### PR DESCRIPTION
```
 In file included from Unified_cpp_widget_gtk2.cpp:2:
 In file included from /<<BUILDDIR>>/waterfox/widget/gtk/nsClipboardWayland.cpp:12:
 /<<BUILDDIR>>/waterfox/widget/gtk/nsClipboardWayland.h:53:30: error: unknown type name 'nsWaylandDragContext'
   void SetWaylandDragContext(nsWaylandDragContext* aDragContext);
                              ^
 /<<BUILDDIR>>/waterfox/widget/gtk/nsClipboardWayland.h:54:3: error: unknown type name 'nsWaylandDragContext'
   nsWaylandDragContext* GetWaylandDragContext();
   ^
 /<<BUILDDIR>>/waterfox/widget/gtk/nsClipboardWayland.h:62:10: error: use of undeclared identifier 'nsWaylandDragContext'
   RefPtr<nsWaylandDragContext> mDragContext;
```