### PR TITLE
[WFX-501] Prevent forcibly enabling Waterfox default theme on upgrade.

### DIFF
--- a/waterfox/browser/components/WaterfoxGlue.jsm
+++ b/waterfox/browser/components/WaterfoxGlue.jsm
@@ -310,8 +310,6 @@ const WaterfoxGlue = {
           case "australis-dark@waterfox.net":
             enableTheme("firefox-compact-dark@mozilla.org");
             break;
-          default:
-            enableTheme(DEFAULT_THEME);
         }
       } else {
         // If no activeTheme detected, set default.


### PR DESCRIPTION
Resolve #2814 