### PR TITLE
Disable Nightly check for JPEG XL support

### DIFF
--- a/toolkit/moz.configure
+++ b/toolkit/moz.configure
@@ -689,9 +689,9 @@ set_define("MOZ_AV1", av1)
 option("--disable-jxl", help="Disable jxl image support")
 
 
-@depends("--disable-jxl", milestone.is_nightly)
-def jxl(value, is_nightly):
-    if is_nightly and value:
+@depends("--disable-jxl")
+def jxl(value):
+    if value:
         return True
 
 


### PR DESCRIPTION
As mentioned in #2924, 4e1dca751406fe4a71435f2088c9ac4eae7d41ad does not actually affect anything, because JPEG XL support is disabled in anything but Nightly builds.

Weirdly, the `image.jxl.enabled` config option is already set to `true` by default in [000-waterfox.js](https://github.com/WaterfoxCo/Waterfox/blob/4e1dca751406fe4a71435f2088c9ac4eae7d41ad/waterfox/browser/app/profile/000-waterfox.js#L98). This means that **all Waterfox releases** have broken JPEG XL support, since Firefox (and therefore Waterfox) sends the `Accept: image/jxl` header even if the JXL decoding support is not actually built and present.

This leads to issues such as [missing pictures on Shopify-powered sites](https://github.com/WaterfoxCo/Waterfox/issues/2924#issuecomment-1361054106):
> As a heads up, enabling JPEG XL support seems to break various websites in G5.1.1, for example [MagicHolz](https://magicholz.de/). With enabled JPEG XL support (image.jxl.enabled set to true) various images on the website do not load anymore.

This should fix it by _actually_ enabling JPEG XL support out-of-the box in all builds by removing the Nightly check.

Additionally, this test page by Jon Sneyers may prove useful: https://jpegxl.info/test-page/