### PR TITLE
Add a few missing <cstdint> includes

### DIFF
--- a/dom/media/webrtc/sdp/RsdparsaSdpGlue.cpp
+++ b/dom/media/webrtc/sdp/RsdparsaSdpGlue.cpp
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include <string>
+#include <cstdint>
 
 #include "sdp/RsdparsaSdpInc.h"
 #include "sdp/RsdparsaSdpGlue.h"

--- a/gfx/2d/Rect.h
+++ b/gfx/2d/Rect.h
@@ -15,6 +15,7 @@
 #include "mozilla/Maybe.h"
 
 #include <cmath>
+#include <cstdint>
 
 namespace mozilla {
 

--- a/toolkit/components/telemetry/pingsender/pingsender.cpp
+++ b/toolkit/components/telemetry/pingsender/pingsender.cpp
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <cstdlib>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <fstream>


### PR DESCRIPTION
> GCC 13s libstdc++ reduced its dependency on some headers like <cstdint>, so it's no longer transitively included through various headers. Include it explicitly.

> See also: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes
> 
>   11:16.32 .../components/telemetry/pingsender/pingsender.cpp:30:7:
>                     error: unknown type name 'uint32_t'
>   11:16.33 const uint32_t kConnectionTimeoutMs = 30 * 1000;
>   11:16.33       ^
>   11:16.33 ... /components/telemetry/pingsender/pingsender.cpp:76:9:
>                     error: unknown type name 'uint32_t'
>   11:16.33   const uint32_t kBufferSize = 4 * 1024 - 1;
>   11:16.34         ^
>   11:16.44 2 errors generated.
>   (et al)