### PR TITLE
Windows 10 and later: Long Path Aware and use Segment Heaps

### DIFF
--- a/browser/app/waterfox.exe.manifest
+++ b/browser/app/waterfox.exe.manifest
@@ -36,6 +36,12 @@
     </ms_asmv3:requestedPrivileges>
   </ms_asmv3:security>
 </ms_asmv3:trustInfo>
+  <ms_asmv3:application xmlns:ms_asmv3="urn:schemas-microsoft-com:asm.v3">
+    <ms_asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">True</longPathAware>
+      <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+    </ms_asmv3:windowsSettings>
+  </ms_asmv3:application>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>


### PR DESCRIPTION
## Changes the manifest file to allow interacting with [long paths](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation) in Windows 10 v1607 and later, And also changes the used memory heap type from NT heaps to [Segment heaps](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#heaptype) in Windows 10 v2004 and later.

Note: "[LongPathsEnabled](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry)" must be turned on in registry for long path handling to work although there are quite a few random third party programs that do this already as a part of their install process so it's possible this is already enabled for quite a few users whether or not they realize it (a notable example of a program's installer that does this I can think of off the top of my head being [qBittorrent](https://www.qbittorrent.org/)).

The use of Segment heaps should result in less ram/memory used (might also reduce fragmentation in some form/way?) however I have not measured how much exactly, it could be by a minuscule amount or a decent percentage but it depends on factors which I do not know the answers to, also I can confirm there are no stability issues as I have been using Segment heaps in Waterfox (also in other programs as well) for months and months straight with no issues even with long running instances of the browser that have not been closed/restarted for weeks or longer. Also as a side note Segment heaps have been around since the early days of Windows 10 (since around 2015) and are in use by default for all UWP apps and a few critical system win32 apps, the reason the manifest tweak only applies to Win10 v2004 and later is because the ability to use segment heaps was only available to do through registry until 2020 when a way to use it with manifests was added.

Below are some before and after screenshots confirming this manifest file does indeed function.

# **BEFORE**:
![waterfox longpath aware before 1.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/ecd3a356-0d1e-4e6e-8da1-05d8b59b7696)
![waterfox longpath aware before 2.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/cd71d29c-922a-4cd3-8b35-1d67ab578d3c)
![waterfox segment heap before.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/29d09ca4-d389-47b5-9fe0-0ed6acec06ba)

# **AFTER**:
![waterfox longpath aware after 1.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/8020cf53-7a42-4896-97cd-e09836c98f69)
![waterfox longpath aware after 2.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/042579a0-64e9-471f-a10d-fa85094f9d89)
![waterfox segment heap after.webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/5424fd03-9d47-4e21-8c31-d89447354937)
