### PR TITLE
Add browser.closeShortcut.disabled to disable Ctrl+W

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1171,9 +1171,6 @@ pref("browser.sessionstore.collect_session_storage", true);
 // Don't quit the browser when Ctrl + Q is pressed.
 pref("browser.quitShortcut.disabled", false);
 
-// Don't close window or tab when Ctrl + W is pressed.
-pref("browser.closeShortcut.disabled", false);
-
 // allow META refresh by default
 pref("accessibility.blockautorefresh", false);
 

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1171,6 +1171,9 @@ pref("browser.sessionstore.collect_session_storage", true);
 // Don't quit the browser when Ctrl + Q is pressed.
 pref("browser.quitShortcut.disabled", false);
 
+// Don't close window or tab when Ctrl + W is pressed.
+pref("browser.closeShortcut.disabled", false);
+
 // allow META refresh by default
 pref("accessibility.blockautorefresh", false);
 

--- a/browser/base/content/browser.js
+++ b/browser/base/content/browser.js
@@ -1767,6 +1767,13 @@ var gBrowserInit = {
       )?.removeAttribute("key");
     }
 
+    if (BrowserUIUtils.closeShortcutDisabled) {
+      document.getElementById("key_close").remove();
+      document.getElementById("menu_close").removeAttribute("key");
+      document.getElementById("key_closeWindow").remove();
+      document.getElementById("menu_closeWindow").removeAttribute("key");
+    }
+
     this._loadHandled = true;
   },
 

--- a/browser/base/content/nonbrowser-mac.js
+++ b/browser/base/content/nonbrowser-mac.js
@@ -119,6 +119,12 @@ function nonBrowserWindowStartup() {
       document.getElementById("key_quitApplication").remove();
       document.getElementById("menu_FileQuitItem").removeAttribute("key");
     }
+    if (BrowserUIUtils.closeShortcutDisabled) {
+      document.getElementById("key_close").remove();
+      document.getElementById("menu_close").removeAttribute("key");
+      document.getElementById("key_closeWindow").remove();
+      document.getElementById("menu_closeWindow").removeAttribute("key");
+    }
   }
 
   delayedStartupTimeoutId = setTimeout(nonBrowserWindowDelayedStartup, 0);

--- a/browser/components/tests/browser/browser.ini
+++ b/browser/components/tests/browser/browser.ini
@@ -16,6 +16,8 @@ reason = test depends on update channel
 https_first_disabled = true
 [browser_quit_disabled.js]
 # On macOS we can't change browser.quitShortcut.disabled during runtime.
+[browser_close_disabled.js]
+# On macOS we can't change browser.closeShortcut.disabled during runtime.
 skip-if = os == 'mac'
 [browser_quit_multiple_tabs.js]
 [browser_quit_shortcut_warning.js]

--- a/browser/components/tests/browser/browser_close_disabled.js
+++ b/browser/components/tests/browser/browser_close_disabled.js
@@ -1,0 +1,62 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+add_task(async function test_appMenu_close_disabled() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.closeShortcut.disabled", true]],
+  });
+
+  let win = await BrowserTestUtils.openNewBrowserWindow();
+  let doc = win.document;
+
+  let menuButton = doc.getElementById("PanelUI-menu-button");
+  menuButton.click();
+  await BrowserTestUtils.waitForEvent(win.PanelUI.mainView, "ViewShown");
+
+  let closeButton = doc.querySelector(`[key="key_closeWindow"]`);
+  is(closeButton, null, "No close button with shortcut key");
+
+  await BrowserTestUtils.closeWindow(win);
+
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function test_close_shortcut_disabled() {
+  async function testCloseShortcut(shouldClose) {
+    let win = await BrowserTestUtils.openNewBrowserWindow();
+
+    let closeRequested = false;
+    let observer = {
+      observe(subject, topic, data) {
+        is(topic, "close-application-requested", "Right observer topic");
+        ok(shouldClose, "Close shortcut should NOT have worked");
+
+        // Don't actually close the browser when testing.
+        let cancelClose = subject.QueryInterface(Ci.nsISupportsPRBool);
+        cancelClose.data = true;
+
+        closeRequested = true;
+      },
+    };
+    Services.obs.addObserver(observer, "close-application-requested");
+
+    let modifiers = { accelKey: true };
+    if (AppConstants.platform == "win") {
+      modifiers.shiftKey = true;
+    }
+    EventUtils.synthesizeKey("w", modifiers, win);
+
+    await BrowserTestUtils.closeWindow(win);
+    Services.obs.removeObserver(observer, "close-application-requested");
+
+    is(closeRequested, shouldClose, "Expected close state");
+  }
+
+  // Close shortcut should work when pref is not set.
+  await testCloseShortcut(true);
+
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.closeShortcut.disabled", true]],
+  });
+  await testCloseShortcut(false);
+});

--- a/browser/modules/BrowserUIUtils.jsm
+++ b/browser/modules/BrowserUIUtils.jsm
@@ -177,3 +177,10 @@ XPCOMUtils.defineLazyPreferenceGetter(
   "browser.quitShortcut.disabled",
   false
 );
+
+XPCOMUtils.defineLazyPreferenceGetter(
+  BrowserUIUtils,
+  "closeShortcutDisabled",
+  "browser.closeShortcut.disabled",
+  false
+);

--- a/waterfox/browser/app/profile/00-waterfox.js
+++ b/waterfox/browser/app/profile/00-waterfox.js
@@ -89,6 +89,8 @@ pref("signon.management.page.mobileAppleURL", "", locked);
 pref("signon.recipes.remoteRecipes.enabled", false, locked);
 pref("svg.context-properties.content.enabled", true);
 pref("toolkit.legacyUserProfileCustomizations.stylesheets", true, locked);
+// Don't close window or tab when Ctrl + W is pressed.
+pref("browser.closeShortcut.disabled", false);
 
 // Extensibles prefs
 pref("browser.tabs.duplicateTab", true);


### PR DESCRIPTION
Implemented option to disable the `Ctrl+W` shortcut based on existing `Ctrl+Q` implementation