### PR TITLE
Windows: Allow hardware acceleration in VMware

### DIFF
--- a/widget/windows/GfxInfo.cpp
+++ b/widget/windows/GfxInfo.cpp
@@ -1944,6 +1944,9 @@ nsresult GfxInfo::GetFeatureStatusImpl(
         !adapterVendorID.Equals(
             GfxDriverInfo::GetDeviceVendor(DeviceVendor::Qualcomm),
             nsCaseInsensitiveStringComparator) &&
+        !adapterVendorID.Equals(
+            GfxDriverInfo::GetDeviceVendor(DeviceVendor::VMWare),
+            nsCaseInsensitiveStringComparator) &&
         // FIXME - these special hex values are currently used in xpcshell tests
         // introduced by bug 625160 patch 8/8. Maybe these tests need to be
         // adjusted now that we're only whitelisting intel/ati/nvidia.
@@ -1953,9 +1956,6 @@ nsresult GfxInfo::GetFeatureStatusImpl(
         !adapterVendorID.LowerCaseEqualsLiteral("0xdcdc")) {
       if (adapterVendorID.Equals(
               GfxDriverInfo::GetDeviceVendor(DeviceVendor::MicrosoftHyperV),
-              nsCaseInsensitiveStringComparator) ||
-          adapterVendorID.Equals(
-              GfxDriverInfo::GetDeviceVendor(DeviceVendor::VMWare),
               nsCaseInsensitiveStringComparator) ||
           adapterVendorID.Equals(
               GfxDriverInfo::GetDeviceVendor(DeviceVendor::VirtualBox),


### PR DESCRIPTION
Allows GPU hardware acceleration to be used in VMware guest machines since newer versions of VMware have the things needed such as DirectX 11 support (Also Chromium based browsers allow GPU acceleration), I tested hardware acceleration in VMware by tricking current builds of Waterfox with environment variables and things seemed to work fine and if for some reason they didn't then the software fallback is always available.

This pull request should/will solve [bug 1429587](https://bugzilla.mozilla.org/show_bug.cgi?id=1429587#c7)

This could possibly be extended to VirtualBox as well however they only recently got DirectX 11 support and I haven't had a chance to test how well it works.