### PR TITLE
Trust binaries signed for Waterfox (about:third-party)

### DIFF
--- a/toolkit/xre/dllservices/ModuleEvaluator.cpp
+++ b/toolkit/xre/dllservices/ModuleEvaluator.cpp
@@ -170,6 +170,8 @@ Maybe<ModuleTrustFlags> ModuleEvaluator::GetTrust(
       return Some(ModuleTrustFlags::MicrosoftWindowsSignature);
     } else if (signedBy.EqualsLiteral("Mozilla Corporation")) {
       return Some(ModuleTrustFlags::MozillaSignature);
+    } else if (signedBy.EqualsLiteral("BrowserWorks Ltd")) {
+      return Some(ModuleTrustFlags::MozillaSignature);
     } else {
       // Being signed by somebody who is neither Microsoft nor us is an
       // automatic and immediate disqualification.


### PR DESCRIPTION
This should fix [`about:third-party`](https://hacks.mozilla.org/2023/03/letting-users-block-injected-third-party-dlls-in-firefox/) not trusting any of Waterfox's DLL files.
This means the user can no longer "brick" their browser as shown in the images below, it also might improve performance to some extent since now the browser won't do any checking against core browser DLLs treating them like they are unknown.
Also this may help or solve issue https://github.com/WaterfoxCo/Waterfox/issues/3187 although this is just a guess.

## core browser DLL being treated as unknown/third-party:
![Untitled31 webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/960bdc56-990d-42c5-9cb9-4f5175b70003)
## the result of blocking xul.dll and then attempting to launch Waterfox (the only way to get Waterfox working again is to go to `%AppData%\WaterfoxLimited\Waterfox\` In Windows and delete everything in the "`disabled`" folder.):
![Untitled32 webp](https://github.com/WaterfoxCo/Waterfox/assets/61405538/0a223fdd-c1a8-473e-a022-a4d9e5a003a4)
