### PR TITLE
Fix profile refresh functionality

### DIFF
--- a/toolkit/modules/ResetProfile.sys.mjs
+++ b/toolkit/modules/ResetProfile.sys.mjs
@@ -24,7 +24,7 @@ XPCOMUtils.defineLazyGetter(lazy, "MigrationUtils", () => {
   return undefined;
 });
 
-const MOZ_APP_NAME = AppConstants.MOZ_APP_NAME;
+const MOZ_APP_NAME = "firefox";
 
 export var ResetProfile = {
   /**


### PR DESCRIPTION
To fix profile refreshing, it required an update to ResetProfile.sys.mjs as it was trying to find a non existent waterfox migrator.
