### PR TITLE
[G6 only] FIx `gfx.webrender.super-resolution.nvidia`

### DIFF
--- a/gfx/webrender_bindings/DCLayerTree.cpp
+++ b/gfx/webrender_bindings/DCLayerTree.cpp
@@ -1367,7 +1367,7 @@ static void SetNvidiaVideoSuperRes(ID3D11VideoContext* videoContext,
     UINT method;
     UINT enable;
   } streamExtensionInfo = {nvExtensionVersion, nvExtensionMethodSuperResolution,
-                           enabled ? 0 : 1u};
+                           enabled ? 1u : 0};
 
   HRESULT hr;
   hr = videoContext->VideoProcessorSetStreamExtension(


### PR DESCRIPTION
Fixes `gfx.webrender.super-resolution.nvidia` not working properly.
https://bugzilla.mozilla.org/show_bug.cgi?id=1838781
https://phabricator.services.mozilla.com/D182609