### PR TITLE
Change Oblivious DNS over HTTP to Oblivious DNS over HTTPS

### DIFF
--- a/netwerk/dns/TRRService.cpp
+++ b/netwerk/dns/TRRService.cpp
@@ -55,7 +55,7 @@ constexpr nsLiteralCString kTRRDomains[3][7] = {
     "private.canadianshield.cira.ca"_ns,
     "doh.xfinity.com"_ns,  // Steered clients
     "dns.shaw.ca"_ns, // Steered clients
-    "dooh.cloudflare-dns.com"_ns, // DNS over Oblivious HTTP
+    "dooh.cloudflare-dns.com"_ns, // DNS over Oblivious HTTPS
     },
     {
     "(other)_2"_ns,
@@ -64,7 +64,7 @@ constexpr nsLiteralCString kTRRDomains[3][7] = {
     "private.canadianshield.cira.ca_2"_ns,
     "doh.xfinity.com_2"_ns,  // Steered clients
     "dns.shaw.ca_2"_ns, // Steered clients
-    "dooh.cloudflare-dns.com_2"_ns, // DNS over Oblivious HTTP
+    "dooh.cloudflare-dns.com_2"_ns, // DNS over Oblivious HTTPS
     },
     {
     "(other)_3"_ns,
@@ -73,7 +73,7 @@ constexpr nsLiteralCString kTRRDomains[3][7] = {
     "private.canadianshield.cira.ca_3"_ns,
     "doh.xfinity.com_3"_ns,  // Steered clients
     "dns.shaw.ca_3"_ns, // Steered clients
-    "dooh.cloudflare-dns.com_3"_ns, // DNS over Oblivious HTTP
+    "dooh.cloudflare-dns.com_3"_ns, // DNS over Oblivious HTTPS
     },
     // clang-format on
 };

--- a/toolkit/components/nimbus/FeatureManifest.yaml
+++ b/toolkit/components/nimbus/FeatureManifest.yaml
@@ -1228,20 +1228,20 @@ dohPrefs:
       setPref: "network.trr_ui.show_fallback_warning_option"
 
 dooh:
-  description: "DNS over Oblivious HTTP"
+  description: "DNS over Oblivious HTTPS"
   owner: vgosu@mozilla.com
   hasExposure: false
   variables:
     ohttpEnabled:
-      description: Whether to use Oblivious HTTP for the resolution
+      description: Whether to use Oblivious HTTPS for the resolution
       type: boolean
       setPref: "network.trr.use_ohttp"
     ohttpRelayUri:
-      description: The URL of the Oblivious HTTP relay
+      description: The URL of the Oblivious HTTPS relay
       type: string
       setPref: "network.trr.ohttp.relay_uri"
     ohttpConfigUri:
-      description: The URL used to fetch the configuration of the Oblivious HTTP gateway
+      description: The URL used to fetch the configuration of the Oblivious HTTPS gateway
       type: string
       setPref: "network.trr.ohttp.config_uri"
     ohttpUri:

--- a/waterfox/browser/locales/en-US/waterfox.ftl
+++ b/waterfox/browser/locales/en-US/waterfox.ftl
@@ -115,7 +115,7 @@ load-images =
 enable-javascript =
     .label = Enable JavaScript
 enable-dooh = 
-    .label = Use DNS over Oblivious HTTP
+    .label = Use DNS over Oblivious HTTPS
 webrtc-header = WebRTC peer connection
 ref-header = HTTP Referrer Header
 ### Look & Feel


### PR DESCRIPTION
Hello! 

For some reason there is no S in Oblivious DNS over HTTPS almost anywhere in this project.

For example:
https://www.waterfox.net/blog/waterfox-in-2023/#dns-over-oblivious-http
https://www.waterfox.net/docs/releases/G6.0.1/

More importantly, it says Oblivious DNS over HTTP in the browser itself:
![image](https://github.com/WaterfoxCo/Waterfox/assets/12563436/86f74569-b4da-427b-a415-4477c6f42604)

Is the implementation in Waterfox unencrypted, or is the missing S a typo?

Regardless, this fixes that in the descriptions/comments and in the en-US locale of the browser.

There are still functions named stuff like oblivious_http but I ain't touching that.

In an unrelated note, it seems impossible to use anything but CloudFlare for this feature. Any plans of changing that? Just curious.

Thanks for making this browser!