### PR TITLE
Fix build for LLVM/Clang 18+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,8 +414,8 @@ dependencies = [
 [[package]]
 name = "bindgen"
 version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+#source = "registry+https://github.com/rust-lang/crates.io-index"
+#checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,3 +191,8 @@ uniffi_bindgen = "=0.23.0"
 uniffi_build = "=0.23.0"
 uniffi_macros = "=0.23.0"
 weedle2 = "=4.0.0"
+
+[patch.crates-io.bindgen_0_64_0]
+package = "bindgen"
+version = "0.64.0"
+path = "third_party/rust/bindgen"

--- a/dom/media/gmp-plugin-openh264/gmp-fake-openh264.cpp
+++ b/dom/media/gmp-plugin-openh264/gmp-fake-openh264.cpp
@@ -99,7 +99,7 @@ struct EncodedFrame {
     uint8_t y_;
     uint8_t u_;
     uint8_t v_;
-    uint32_t timestamp_;
+    uint64_t timestamp_;
   } idr_nalu;
 };
 #pragma pack(pop)

--- a/dom/media/gtest/TestGMPRemoveAndDelete.cpp
+++ b/dom/media/gtest/TestGMPRemoveAndDelete.cpp
@@ -361,7 +361,7 @@ void GMPRemoveTest::gmp_Decode() {
       uint8_t y_;
       uint8_t u_;
       uint8_t v_;
-      uint32_t timestamp_;
+      uint64_t timestamp_;
     } idr_nalu;
   };
 #pragma pack(pop)

--- a/dom/media/webrtc/libwebrtcglue/WebrtcGmpVideoCodec.cpp
+++ b/dom/media/webrtc/libwebrtcglue/WebrtcGmpVideoCodec.cpp
@@ -540,7 +540,7 @@ void WebrtcGmpVideoEncoder::Encoded(
 
   webrtc::VideoFrameType ft;
   GmpFrameTypeToWebrtcFrameType(aEncodedFrame->FrameType(), &ft);
-  uint32_t timestamp = (aEncodedFrame->TimeStamp() * 90ll + 999) / 1000;
+  uint64_t timestamp = (aEncodedFrame->TimeStamp() * 90ll + 999) / 1000;
 
   GMP_LOG_DEBUG("GMP Encoded: %" PRIu64 ", type %d, len %d",
                 aEncodedFrame->TimeStamp(), aEncodedFrame->BufferType(),

--- a/dom/media/webrtc/libwebrtcglue/WebrtcGmpVideoCodec.h
+++ b/dom/media/webrtc/libwebrtcglue/WebrtcGmpVideoCodec.h
@@ -302,7 +302,7 @@ class WebrtcGmpVideoEncoder : public GMPVideoEncoderCallbackProxy,
     int64_t timestamp_us;
   };
   // Map rtp time -> input image data
-  DataMutex<std::map<uint32_t, InputImageData>> mInputImageMap;
+  DataMutex<std::map<uint64_t, InputImageData>> mInputImageMap;
 
   MediaEventProducer<uint64_t> mInitPluginEvent;
   MediaEventProducer<uint64_t> mReleasePluginEvent;

--- a/third_party/rust/bindgen/ir/item.rs
+++ b/third_party/rust/bindgen/ir/item.rs
@@ -1428,8 +1428,11 @@ impl Item {
         }
 
         match cursor.kind() {
-            // Guess how does clang treat extern "C" blocks?
-            CXCursor_UnexposedDecl => Err(ParseError::Recurse),
+            // On Clang 18+, extern "C" is reported accurately as a LinkageSpec.
+            // Older LLVM treat it as UnexposedDecl.
+            CXCursor_LinkageSpec | CXCursor_UnexposedDecl => {
+                Err(ParseError::Recurse)
+            }
 
             // We allowlist cursors here known to be unhandled, to prevent being
             // too noisy about this.


### PR DESCRIPTION
Sources:
https://cgit.freebsd.org/ports/tree/www/firefox-esr/files/patch-llvm18
https://github.com/pld-linux/thunderbird/blob/master/llvm18.patch
https://build.opensuse.org/projects/mozilla/packages/firefox115esr/files/mozilla-fix-issues-with-llvm18.patch

Alternative way could be updating bindgen directly, but probably that might be not so easy.