### PR TITLE
Trust additional binaries signed by Microsoft

### DIFF
--- a/toolkit/xre/dllservices/ModuleEvaluator.cpp
+++ b/toolkit/xre/dllservices/ModuleEvaluator.cpp
@@ -172,6 +172,8 @@ Maybe<ModuleTrustFlags> ModuleEvaluator::GetTrust(
       return Some(ModuleTrustFlags::MicrosoftWindowsSignature);
     } else if (signedBy.EqualsLiteral("Microsoft Corporation")) {
       return Some(ModuleTrustFlags::MicrosoftWindowsSignature);
+    } else if (signedBy.EqualsLiteral("Microsoft Windows Software Compatibility Publisher")) {
+      return Some(ModuleTrustFlags::MicrosoftWindowsSignature);
     } else if (signedBy.EqualsLiteral("Mozilla Corporation")) {
       return Some(ModuleTrustFlags::MozillaSignature);
     } else if (signedBy.EqualsLiteral("BrowserWorks Ltd")) {


### PR DESCRIPTION
This fixes about:third-party not trusting some DLLs from Microsoft that are required similar to https://github.com/BrowserWorks/Waterfox/pull/3269.
makes it so DLLs such as `vcruntime140.dll`, `vcruntime140_1.dll`, and `msvcp140.dll` stop being detected in about:third-party, The reason this happens in the first place is because it seems like only the first signature string within a DLL is checked and for these DLLs "`Microsoft Windows Software Compatibility Publisher`" is the first signature.