### PR TITLE
fix: submodules best practices

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "waterfox/browser/locales"]
 	path = waterfox/browser/locales
-	url = git@github.com:BrowserWorks/l10n.git
+	url = https://github.com/BrowserWorks/l10n.git


### PR DESCRIPTION
I've noticed cloning the project for the first time using `git clone --depth=1 --recursive https://github.com/BrowserWorks/Waterfox.git`

I get an error that I dont have permissions for a submodule `git@github.com:BrowserWorks/l10n.git`

```
fatal: clone of 'git@github.com:BrowserWorks/l10n.git' into submodule path '...' failed
Failed to clone 'waterfox/browser/locales'. Retry scheduled
...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:BrowserWorks/l10n.git' into submodule path '...' failed
Failed to clone 'waterfox/browser/locales' a second time, aborting
```

I'm sure there is a way to configure git to be able to clone with this format. None the less, I believe this change would make it easier for new contributors cloning for the first time