### PR TITLE
Attempt to enable/compile with zlib-rs

### DIFF
--- a/moz.configure
+++ b/moz.configure
@@ -929,7 +929,7 @@ set_config("MOZ_SYSTEM_ZLIB", True, when="--with-system-zlib")
 
 option(
     env="USE_LIBZ_RS",
-    default=True
+    default=True,
     help="Use libz-rs-sys instead of zlib",
     when=toolkit & ~with_system_zlib_option,
 )

--- a/moz.configure
+++ b/moz.configure
@@ -929,7 +929,7 @@ set_config("MOZ_SYSTEM_ZLIB", True, when="--with-system-zlib")
 
 option(
     env="USE_LIBZ_RS",
-    default=milestone.is_early_beta_or_earlier,
+    default=True
     help="Use libz-rs-sys instead of zlib",
     when=toolkit & ~with_system_zlib_option,
 )


### PR DESCRIPTION
This PR attempts to enable compiling with zlib-rs instead of regular zlib which should lead to a nice performance bump for anything related to deflate compression or decompression such as handling PNGs files or decoding gzip encoded files/assets/streams from web servers.
The reason this PR is labeled as an "attempt" is because I am not 100% sure if this is the right way to go about enabling it (I am not familiar with the Python build system of Gecko) however I cannot test myself since I am unable to compile Waterfox.


relevant bugzilla post: https://bugzilla.mozilla.org/show_bug.cgi?id=1910796