### PR TITLE
Fixed a wrong file reference to make entitlements work again (presuma…

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -1034,7 +1034,7 @@ mac-signing:
                           default:
                               by-project:
                                   mozilla-central: security/mac/hardenedruntime/production/nightly.browser.xml
-                                  default: security/mac/hardenedruntime/production/firefox.browser.xml
+                                  default: security/mac/hardenedruntime/production/browser.xml
                   globs:
                       - "/"  # The .app
 


### PR DESCRIPTION
This presumably fixes entitlements on macOS. The wrong config file was referenced. See issue #3755