### PR TITLE
Windows: enable Printer Driver Isolation

### DIFF
--- a/browser/app/waterfox.exe.manifest
+++ b/browser/app/waterfox.exe.manifest
@@ -38,6 +38,7 @@
 </ms_asmv3:trustInfo>
   <ms_asmv3:application xmlns:ms_asmv3="urn:schemas-microsoft-com:asm.v3">
     <ms_asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+      <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">True</printerDriverIsolation>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">True</longPathAware>
       <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
     </ms_asmv3:windowsSettings>


### PR DESCRIPTION
Makes it to that when interacting with printer drivers on Windows when trying to print a page it will be done in a separate dedicated process (`splwow64.exe`) so that a bad/unstable printer driver can't crash or mess with the browser.
[learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#printerdriverisolation](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#printerdriverisolation)
[peteronprogramming.wordpress.com/2018/01/22/application-level-printer-driver-isolation](https://peteronprogramming.wordpress.com/2018/01/22/application-level-printer-driver-isolation/)

I did testing to make sure that this worked and checked that the `splwow64.exe` process was actually getting created and used with printing still functional within the browser.
As for why this isn't already included in the browser manifest my conclusion is that Mozilla is simply unaware this is even a thing because Microsoft doesn't do a very good job of making it known this is an option and as a result many developers are just unaware of it's existence. In the future I might see about submitting this to upstream Firefox directly however the process for doing so seems to require a lot more effort.