### PR TITLE
fix(gfx): wire up WebRender gradient dithering (backport)

### DIFF
--- a/gfx/webrender_bindings/src/bindings.rs
+++ b/gfx/webrender_bindings/src/bindings.rs
@@ -1978,6 +1978,12 @@ pub extern "C" fn wr_window_new(
         }
     };
 
+    let enable_dithering = if !software && static_prefs::pref!("gfx.webrender.dithering") {
+        true
+    } else {
+        false
+    };
+
     let opts = WebRenderOptions {
         enable_aa: true,
         enable_subpixel_aa,
@@ -2032,6 +2038,7 @@ pub extern "C" fn wr_window_new(
         reject_software_rasterizer,
         low_quality_pinch_zoom,
         max_shared_surface_size,
+        enable_dithering,
         ..Default::default()
     };
 
@@ -4434,8 +4441,11 @@ pub extern "C" fn wr_shaders_new(
 
     device.begin_frame();
 
+    let mut options = WebRenderOptions::default();
+    options.enable_dithering = static_prefs::pref!("gfx.webrender.dithering");
+
     let gl_type = device.gl().get_type();
-    let mut shaders = match Shaders::new(&mut device, gl_type, &WebRenderOptions::default()) {
+    let mut shaders = match Shaders::new(&mut device, gl_type, &options) {
         Ok(shaders) => shaders,
         Err(e) => {
             warn!(" Failed to create a Shaders: {:?}", e);

--- a/gfx/wr/webrender/src/renderer/shade.rs
+++ b/gfx/wr/webrender/src/renderer/shade.rs
@@ -695,6 +695,12 @@ impl Shaders {
         shader_flags.set(ShaderFeatureFlags::DITHERING, options.enable_dithering);
         let shader_list = get_shader_features(shader_flags);
 
+        let dither_feature: &[&str] = if options.enable_dithering {
+            &[DITHERING_FEATURE]
+        } else {
+            &[]
+        };
+
         let mut loader = ShaderLoader::new();
 
         let brush_solid = BrushShader::new(
@@ -726,11 +732,7 @@ impl Shaders {
 
         let brush_linear_gradient = BrushShader::new(
             "brush_linear_gradient",
-            if options.enable_dithering {
-               &[DITHERING_FEATURE]
-            } else {
-               &[]
-            },
+            dither_feature,
             &shader_list,
             false /* advanced blend */,
             false /* dual source */,
@@ -874,14 +876,14 @@ impl Shaders {
         let ps_quad_radial_gradient = loader.create_shader(
             ShaderKind::Primitive,
             "ps_quad_radial_gradient",
-            &[],
+            dither_feature,
             &shader_list,
         )?;
 
         let ps_quad_conic_gradient = loader.create_shader(
             ShaderKind::Primitive,
             "ps_quad_conic_gradient",
-            &[],
+            dither_feature,
             &shader_list,
         )?;
 
@@ -1022,21 +1024,21 @@ impl Shaders {
         let cs_linear_gradient = loader.create_shader(
             ShaderKind::Cache(VertexArrayKind::LinearGradient),
             "cs_linear_gradient",
-            &[],
+            dither_feature,
             &shader_list,
         )?;
 
         let cs_radial_gradient = loader.create_shader(
             ShaderKind::Cache(VertexArrayKind::RadialGradient),
             "cs_radial_gradient",
-            &[],
+            dither_feature,
             &shader_list,
         )?;
 
         let cs_conic_gradient = loader.create_shader(
             ShaderKind::Cache(VertexArrayKind::ConicGradient),
             "cs_conic_gradient",
-            &[],
+            dither_feature,
             &shader_list,
         )?;
 

--- a/gfx/wr/webrender_build/src/shader_features.rs
+++ b/gfx/wr/webrender_build/src/shader_features.rs
@@ -88,6 +88,8 @@ pub fn get_shader_features(flags: ShaderFeatureFlags) -> ShaderFeatures {
         "cs_linear_gradient",
         "cs_radial_gradient",
         "cs_conic_gradient",
+        "ps_quad_radial_gradient",
+        "ps_quad_conic_gradient",
     ] {
         let mut features = Vec::new();
         features.push(String::new());
@@ -241,10 +243,6 @@ pub fn get_shader_features(flags: ShaderFeatureFlags) -> ShaderFeatures {
     shaders.insert("ps_split_composite", vec![base_prim_features.finish()]);
 
     shaders.insert("ps_quad_textured", vec![base_prim_features.finish()]);
-
-    shaders.insert("ps_quad_radial_gradient", vec![base_prim_features.finish()]);
-
-    shaders.insert("ps_quad_conic_gradient", vec![base_prim_features.finish()]);
 
     shaders.insert("ps_clear", vec![base_prim_features.finish()]);
 

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -7313,6 +7313,13 @@
   value: false
   mirror: once
 
+# Enable dithering in hardware WebRender
+- name: gfx.webrender.dithering
+  type: bool
+  rust: true
+  value: true
+  mirror: once
+
 #ifdef XP_WIN
 - name: gfx.webrender.force-angle
   type: bool


### PR DESCRIPTION
A very minimal backport fixing the handling of the `gfx.webrender.dithering` not working in FF ESR 140 - gradients looked always banded. Backports the relevant pieces of Firefox 144's dithering wiring ([Bug 1984549](https://bugzilla.mozilla.org/show_bug.cgi?id=1984549)).

Tested locally on macOS arm64/intel - gradient banding visible with pref off, smooth with pref on. If needed I can upload some screenshots to verify.

NOTE: Once the next ESR version of Firefox is released sometime later this year, this fix will no longer be needed. For now it allows us to see beautiful dithered gradients like in Chrome and the latest non-ESR version of Firefox.