### PR TITLE
feat: add cookie exception control to site identity popup

### DIFF
--- a/browser/base/content/browser-siteIdentity.js
+++ b/browser/base/content/browser-siteIdentity.js
@@ -216,6 +216,9 @@ var gIdentityHandler = {
       "identity-popup-clear-sitedata-button": event => {
         this.clearSiteData(event);
       },
+      "identity-popup-allow-sitedata-button": () => {
+        this.toggleSiteData();
+      },
       "identity-popup-remove-cert-exception": () => {
         this.removeCertException();
       },
@@ -461,6 +464,33 @@ var gIdentityHandler = {
     }
 
     event.stopPropagation();
+  },
+
+  async refreshSiteData() {
+    document.getElementById("identity-popup-allow-sitedata-toggle").toggleAttribute(
+      "pressed",
+      Services.perms.testExactPermissionFromPrincipal(
+        gBrowser.contentPrincipal,
+        "cookie"
+      ) === Services.perms.ALLOW_ACTION
+    );
+  },
+
+  async toggleSiteData() {
+    const pressed = document.getElementById("identity-popup-allow-sitedata-toggle").toggleAttribute(
+      "pressed"
+    );
+
+    if (pressed) {
+      Services.perms.addFromPrincipal(
+        gBrowser.contentPrincipal,
+        "cookie",
+        Services.perms.ALLOW_ACTION,
+        Services.perms.EXPIRE_NEVER
+      );
+    } else {
+      Services.perms.removeFromPrincipal(gBrowser.contentPrincipal, "cookie");
+    }
   },
 
   /**
@@ -1190,6 +1220,8 @@ var gIdentityHandler = {
     this._identityPopupContentOwner.textContent = owner;
     this._identityPopupContentSupp.textContent = supplemental;
     this._identityPopupContentVerif.textContent = verifier;
+
+    this.refreshSiteData();
   },
 
   setURI(uri) {

--- a/browser/components/controlcenter/content/identityPanel.inc.xhtml
+++ b/browser/components/controlcenter/content/identityPanel.inc.xhtml
@@ -98,6 +98,11 @@
         <toolbarbutton id="identity-popup-clear-sitedata-button"
                 data-l10n-id="identity-clear-site-data"
                 class="subviewbutton"/>
+        <toolbarbutton id="identity-popup-allow-sitedata-button"
+                class="subviewbutton">
+          <label data-l10n-id="identity-allow-site-data" flex="1"></label>
+          <html:moz-toggle id="identity-popup-allow-sitedata-toggle" style="pointer-events: none;"></html:moz-toggle>
+        </toolbarbutton>
       </vbox>
     </panelview>
 

--- a/browser/locales/en-US/browser/browser.ftl
+++ b/browser/locales/en-US/browser/browser.ftl
@@ -461,6 +461,7 @@ identity-permissions-storage-access-learn-more = Learn more
 identity-permissions-reload-hint = You may need to reload the page for changes to apply.
 identity-clear-site-data =
     .label = Clear cookies and site data…
+identity-allow-site-data = Always store cookies/data for this site
 identity-connection-not-secure-security-view = You are not securely connected to this site.
 identity-connection-verified = You are securely connected to this site.
 identity-ev-owner-label = Certificate issued to:


### PR DESCRIPTION
Based on https://codeberg.org/librewolf/source/src/commit/9e8bf19710707440704242cf61aa6fb6da186210/patches/ui-patches/allow_cookies_for_site.patch

Resolves #3354